### PR TITLE
fix: use correct bucket when downloading images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
     - name: "download images"
       run: |
         echo "downloading images to $(pwd)/images"
-        gsutil cp -r gs://loki-build-artifacts/${{ needs.createRelease.outputs.sha }}/images .
+        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/${{ needs.createRelease.outputs.sha }}/images .
     - name: "publish docker images"
       uses: "./lib/actions/push-images"
       with:

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -176,7 +176,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         step.new('download images')
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
-          gsutil cp -r gs://loki-build-artifacts/${{ needs.createRelease.outputs.sha }}/images .
+          gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/${{ needs.createRelease.outputs.sha }}/images .
         |||),
         step.new('publish docker images', './lib/actions/push-images')
         + step.with({


### PR DESCRIPTION
Still using hardcoded loki bucket when downloading images, this fixes that step to use the env var.