### PR TITLE
fix: added cleanup step before running `dist` stage.

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -93,6 +93,8 @@ jobs:
       version: "${{ needs.version.outputs.version }}"
     runs-on: "ubuntu-latest"
     steps:
+    - name: "clean up build tools cache"
+      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -93,6 +93,8 @@ jobs:
       version: "${{ needs.version.outputs.version }}"
     runs-on: "ubuntu-latest"
     steps:
+    - name: "clean up build tools cache"
+      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -176,6 +176,7 @@ local releaseLibStep = common.releaseLibStep;
   dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'])
     job.new()
     + job.withSteps([
+      common.cleanUpBuildCache,
       common.fetchReleaseRepo,
       common.googleAuth,
       common.setupGoogleCloudSdk,

--- a/workflows/common.libsonnet
+++ b/workflows/common.libsonnet
@@ -75,6 +75,10 @@
   checkout:
     $.step.new('checkout', 'actions/checkout@v4'),
 
+  cleanUpBuildCache:
+    $.step.new('clean up build tools cache')
+    + $.step.withRun('rm -rf /opt/hostedtoolcache'),
+
   fetchReleaseRepo:
     $.step.new('pull code to release', 'actions/checkout@v4')
     + $.step.with({


### PR DESCRIPTION
added cleanup step to remove 9GB of cache before running `dist` stage.
[Prepare Patch Release PR](https://github.com/grafana/loki/actions/workflows/patch-release-pr.yml) is constantly failing with an error: `no space left on device` ([example](https://github.com/grafana/loki/actions/runs/10299080044/job/28508736330)). 
I found the Github mounts a special folder(cache) with all supported versions of Python, Node, Go, etc, which are used when `Setup Go/Python/etc` action is used ([see](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#specifying-a-python-version)). 
**For the jobs that are executed inside loki-build-image, this cache is not needed at all....**
We could gain free space to win the time until we refactor/redesign our release workflow. 
![image](https://github.com/user-attachments/assets/a68b8375-65c0-4334-8372-b07810f2d083)


PS: I already tried to remove this folder in Loki check step and it did not affect the CI. ([here](https://github.com/grafana/loki/actions/runs/10300957339/job/28511460224?pr=13800))