### PR TITLE
chore: Update docker/build-push-action to v6

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -190,7 +190,7 @@ jobs:
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v5"
+      uses: "docker/build-push-action@v6"
       with:
         build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -190,7 +190,7 @@ jobs:
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v5"
+      uses: "docker/build-push-action@v6"
       with:
         build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -42,7 +42,7 @@ local releaseLibStep = common.releaseLibStep;
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       |||),
 
-      step.new('Build and export', 'docker/build-push-action@v5')
+      step.new('Build and export', 'docker/build-push-action@v6')
       + step.withTimeoutMinutes('${{ fromJSON(env.BUILD_TIMEOUT) }}')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
       + step.withEnv({
@@ -93,7 +93,7 @@ local releaseLibStep = common.releaseLibStep;
         echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
       |||),
 
-      step.new('Build and push', 'docker/build-push-action@v5')
+      step.new('Build and push', 'docker/build-push-action@v6')
       + step.withTimeoutMinutes('${{ fromJSON(env.BUILD_TIMEOUT) }}')
       + step.with({
         context: context,


### PR DESCRIPTION
When running `make release-workflows` in enterprise-logs, the version of `docker/build-push-action` was downgraded from v6 to v5.