### PR TITLE
chore: Move to Go 1.23.1 along with updated golangci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -318,7 +318,7 @@
         "required": true
         "type": "string"
       "golang_ci_lint_version":
-        "default": "v1.55.1"
+        "default": "v1.60.3"
         "description": "version of golangci-lint to use"
         "required": false
         "type": "string"

--- a/.github/workflows/gel-check.yml
+++ b/.github/workflows/gel-check.yml
@@ -183,7 +183,7 @@
         "required": true
         "type": "string"
       "golang_ci_lint_version":
-        "default": "v1.55.1"
+        "default": "v1.60.3"
         "description": "version of golangci-lint to use"
         "required": false
         "type": "string"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,8 +16,8 @@ jobs:
   check:
     uses: "./.github/workflows/check.yml"
     with:
-      build_image: "grafana/loki-build-image:0.33.0"
-      golang_ci_lint_version: "v1.55.1"
+      build_image: "grafana/loki-build-image:0.34.0"
+      golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "release-1.12.x"
       skip_validation: false
       use_github_app_token: true
@@ -135,7 +135,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.33.0"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.0"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -16,8 +16,8 @@ jobs:
   check:
     uses: "./.github/workflows/check.yml"
     with:
-      build_image: "grafana/loki-build-image:0.33.0"
-      golang_ci_lint_version: "v1.55.1"
+      build_image: "grafana/loki-build-image:0.34.0"
+      golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "release-1.12.x"
       skip_validation: false
       use_github_app_token: true
@@ -135,7 +135,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.33.0"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.0"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -9,13 +9,13 @@
   releasePRWorkflow: function(
     branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+'],
     buildArtifactsBucket='loki-build-artifacts',
-    buildImage='grafana/loki-build-image:0.33.0',
+    buildImage='grafana/loki-build-image:0.34.0',
     changelogPath='CHANGELOG.md',
     checkTemplate='./.github/workflows/check.yml',
     distMakeTargets=['dist', 'packages'],
     dryRun=false,
     dockerUsername='grafana',
-    golangCiLintVersion='v1.55.1',
+    golangCiLintVersion='v1.60.3',
     imageBuildTimeoutMin=25,
     imageJobs={},
     imagePrefix='grafana',
@@ -139,7 +139,7 @@
             type: 'boolean',
           },
           golang_ci_lint_version: {
-            default: 'v1.55.1',
+            default: 'v1.60.3',
             description: 'version of golangci-lint to use',
             required: false,
             type: 'string',
@@ -190,7 +190,7 @@
             type: 'boolean',
           },
           golang_ci_lint_version: {
-            default: 'v1.55.1',
+            default: 'v1.60.3',
             description: 'version of golangci-lint to use',
             required: false,
             type: 'string',


### PR DESCRIPTION
Updates Go to 1.23.1
Includes an update to golangci, which supports Go 1.23