### PR TITLE
feat: specify golangci-lint build tags at runtime

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -191,6 +191,7 @@
       "name": "golangci-lint"
       "uses": "golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5"
       "with":
+        "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled"
         "only-new-issues": true
         "version": "${{ inputs.golang_ci_lint_version }}"
   "integration":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -160,6 +160,7 @@ local validationJob = _validationJob(false);
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': true,
+          args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
         }),
       ],
     )


### PR DESCRIPTION
https://github.com/grafana/loki/pull/14456 move the `golangci-lint` build tags to runtime arguments, which will require this change to the `golangci-lint` action