### PR TITLE
chore(build): Fix equality for latest release

### DIFF
--- a/actions/should-release/__tests__/release.test.ts
+++ b/actions/should-release/__tests__/release.test.ts
@@ -184,7 +184,7 @@ describe('release', () => {
     })
   })
 
-  describe('isLastestVersion', () => {
+  describe('isLatestVersion', () => {
     const tags = {
       'v1.3.1': {
         name: 'v1.3.1',
@@ -206,18 +206,43 @@ describe('release', () => {
       ver = Version.parse('2.0.0')
       expect(isLatestVersion(ver, tags)).toBe(true)
     })
-    it('returns flase if the version is not the latest', () => {
+    it('returns false if the version is not the latest', () => {
       let ver = Version.parse('1.2.9')
       expect(isLatestVersion(ver, tags)).toBe(false)
 
       ver = Version.parse('1.3.2')
-      expect(isLatestVersion(ver, tags)).toBe(false)
+      expect(isLatestVersion(ver, tags)).toBe(true)
 
       ver = Version.parse('1.2.0')
       expect(isLatestVersion(ver, tags)).toBe(false)
 
       ver = Version.parse('0.2.0')
       expect(isLatestVersion(ver, tags)).toBe(false)
+    })
+
+    it('handles equal versions correctly', () => {
+      const tagsWithEqual = {
+        'v3.3.3': {
+          name: 'v3.3.3',
+          sha: 'abc123'
+        },
+        'v1.3.2': {
+          name: 'v1.3.2',
+          sha: 'def456'
+        }
+      }
+
+      // This should be false because 3.3.3 exists
+      let ver = Version.parse('3.3.2')
+      expect(isLatestVersion(ver, tagsWithEqual)).toBe(false)
+
+      // This should be true because it's equal to the highest version
+      ver = Version.parse('3.3.3')
+      expect(isLatestVersion(ver, tagsWithEqual)).toBe(true)
+
+      // This should be true because it's higher than any existing version
+      ver = Version.parse('3.3.4')
+      expect(isLatestVersion(ver, tagsWithEqual)).toBe(true)
     })
   })
 })

--- a/actions/should-release/src/release.ts
+++ b/actions/should-release/src/release.ts
@@ -120,7 +120,7 @@ export function isLatestVersion(
   tags: Record<string, GitHubTag>
 ): boolean {
   for (const tag in tags) {
-    if (compareVersions(Version.parse(tags[tag].name), version) >= 0) {
+    if (compareVersions(Version.parse(tags[tag].name), version) > 0) {
       return false
     }
   }


### PR DESCRIPTION
Prior to this change, the check for whether or not something was the "latest" version would return false if the check was against what is the highest version.

For example:
If there was a `3.3.3` release version, and a test came in for the same value, it would return false.

This PR adjusts the logic to ensure that the test for the "latest" version does not short circuit early.

I have included another test case, and adjusted one existing test case for this new behavior.