### PR TITLE
feat: allow GEL to skip docker pluging publishing

### DIFF
--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -90,6 +90,7 @@
     releaseRepo='grafana/loki-release',
     useGitHubAppToken=true,
     dockerPluginPath='clients/cmd/docker-driver',
+    publishDockerPlugins=true,
                   ) {
     name: 'create release',
     on: {
@@ -121,8 +122,11 @@
       shouldRelease: $.release.shouldRelease,
       createRelease: $.release.createRelease,
       publishImages: $.release.publishImages(getDockerCredsFromVault, dockerUsername),
+    } + if publishDockerPlugins then {
       publishDockerPlugins: $.release.publishDockerPlugins(pluginBuildDir, getDockerCredsFromVault, dockerUsername),
       publishRelease: $.release.publishRelease(['createRelease', 'publishImages', 'publishDockerPlugins']),
+    } else {
+      publishRelease: $.release.publishRelease(['createRelease', 'publishImages']),
     },
   },
   check: {


### PR DESCRIPTION
We don't want to publish the docker driver in the GEL build