### PR TITLE
chore(build): Restrict tag version handling to be loki tags

### DIFF
--- a/actions/should-release/__tests__/release.test.ts
+++ b/actions/should-release/__tests__/release.test.ts
@@ -187,16 +187,16 @@ describe('release', () => {
   describe('isLatestVersion', () => {
     const createTags = (versions: string[]): Record<string, GitHubTag> => {
       const tags: Record<string, GitHubTag> = {}
-      versions.forEach(v => {
+      for (const v of versions) {
         tags[v] = {
           name: v,
           sha: `sha-${v}`
         }
-      })
+      }
       return tags
     }
 
-    const tags = {
+    const defaultTags = {
       'v1.3.1': {
         name: 'v1.3.1',
         sha: 'abc123'
@@ -209,27 +209,27 @@ describe('release', () => {
 
     it('returns true if the version is the latest', () => {
       let ver = Version.parse('1.3.3')
-      expect(isLatestVersion(ver, tags)).toBe(true)
+      expect(isLatestVersion(ver, defaultTags)).toBe(true)
 
       ver = Version.parse('1.4.0')
-      expect(isLatestVersion(ver, tags)).toBe(true)
+      expect(isLatestVersion(ver, defaultTags)).toBe(true)
 
       ver = Version.parse('2.0.0')
-      expect(isLatestVersion(ver, tags)).toBe(true)
+      expect(isLatestVersion(ver, defaultTags)).toBe(true)
     })
 
     it('returns false if the version is not the latest', () => {
       let ver = Version.parse('1.2.9')
-      expect(isLatestVersion(ver, tags)).toBe(false)
+      expect(isLatestVersion(ver, defaultTags)).toBe(false)
 
       ver = Version.parse('1.3.2')
-      expect(isLatestVersion(ver, tags)).toBe(true)
+      expect(isLatestVersion(ver, defaultTags)).toBe(true)
 
       ver = Version.parse('1.2.0')
-      expect(isLatestVersion(ver, tags)).toBe(false)
+      expect(isLatestVersion(ver, defaultTags)).toBe(false)
 
       ver = Version.parse('0.2.0')
-      expect(isLatestVersion(ver, tags)).toBe(false)
+      expect(isLatestVersion(ver, defaultTags)).toBe(false)
     })
 
     it('handles equal versions correctly', () => {
@@ -258,7 +258,7 @@ describe('release', () => {
     })
 
     it('handles mixed version formats', () => {
-      const tags = createTags([
+      const mixedTags = createTags([
         'v3.4.0',
         'helm-loki-6.26.0',
         'v3.3.0',
@@ -268,13 +268,13 @@ describe('release', () => {
       ])
 
       // Test semantic versions
-      expect(isLatestVersion(Version.parse('3.4.0'), tags)).toBeFalsy()
-      expect(isLatestVersion(Version.parse('3.5.0'), tags)).toBeTruthy()
-      expect(isLatestVersion(Version.parse('3.3.0'), tags)).toBeFalsy()
+      expect(isLatestVersion(Version.parse('3.4.0'), mixedTags)).toBeFalsy()
+      expect(isLatestVersion(Version.parse('3.5.0'), mixedTags)).toBeTruthy()
+      expect(isLatestVersion(Version.parse('3.3.0'), mixedTags)).toBeFalsy()
 
       // Version that doesn't match pattern should be ignored
-      expect(isLatestVersion(Version.parse('6.25.0'), tags)).toBeTruthy()
-      expect(isLatestVersion(Version.parse('6.27.0'), tags)).toBeTruthy()
+      expect(isLatestVersion(Version.parse('6.25.0'), mixedTags)).toBeTruthy()
+      expect(isLatestVersion(Version.parse('6.27.0'), mixedTags)).toBeTruthy()
     })
   })
 })

--- a/actions/should-release/__tests__/release.test.ts
+++ b/actions/should-release/__tests__/release.test.ts
@@ -185,6 +185,17 @@ describe('release', () => {
   })
 
   describe('isLatestVersion', () => {
+    const createTags = (versions: string[]): Record<string, GitHubTag> => {
+      const tags: Record<string, GitHubTag> = {}
+      versions.forEach(v => {
+        tags[v] = {
+          name: v,
+          sha: `sha-${v}`
+        }
+      })
+      return tags
+    }
+
     const tags = {
       'v1.3.1': {
         name: 'v1.3.1',
@@ -206,6 +217,7 @@ describe('release', () => {
       ver = Version.parse('2.0.0')
       expect(isLatestVersion(ver, tags)).toBe(true)
     })
+
     it('returns false if the version is not the latest', () => {
       let ver = Version.parse('1.2.9')
       expect(isLatestVersion(ver, tags)).toBe(false)
@@ -243,6 +255,26 @@ describe('release', () => {
       // This should be true because it's higher than any existing version
       ver = Version.parse('3.3.4')
       expect(isLatestVersion(ver, tagsWithEqual)).toBe(true)
+    })
+
+    it('handles mixed version formats', () => {
+      const tags = createTags([
+        'v3.4.0',
+        'helm-loki-6.26.0',
+        'v3.3.0',
+        'helm-loki-6.25.0',
+        'v3.5.0',
+        'helm-loki-6.27.0'
+      ])
+
+      // Test semantic versions
+      expect(isLatestVersion(Version.parse('3.4.0'), tags)).toBeFalsy()
+      expect(isLatestVersion(Version.parse('3.5.0'), tags)).toBeTruthy()
+      expect(isLatestVersion(Version.parse('3.3.0'), tags)).toBeFalsy()
+
+      // Version that doesn't match pattern should be ignored
+      expect(isLatestVersion(Version.parse('6.25.0'), tags)).toBeTruthy()
+      expect(isLatestVersion(Version.parse('6.27.0'), tags)).toBeTruthy()
     })
   })
 })

--- a/actions/should-release/src/github.ts
+++ b/actions/should-release/src/github.ts
@@ -62,13 +62,16 @@ export async function findMergedReleasePullRequests(
 }
 
 export async function getAllTags(
-  github: GitHub
+  github: GitHub,
+  versionPattern: RegExp = /^v\d+\.\d+\.\d+$/
 ): Promise<Record<string, GitHubTag>> {
-  const allTags: Record<string, GitHubTag> = {}
+  const tags: Record<string, GitHubTag> = {}
   for await (const tag of github.tagIterator()) {
-    allTags[tag.name] = tag
+    if (versionPattern.test(tag.name)) {
+      tags[tag.name] = tag
+    }
   }
-  return allTags
+  return tags
 }
 
 /**

--- a/actions/should-release/src/github.ts
+++ b/actions/should-release/src/github.ts
@@ -63,7 +63,7 @@ export async function findMergedReleasePullRequests(
 
 export async function getAllTags(
   github: GitHub,
-  versionPattern: RegExp = /^v\d+\.\d+\.\d+$/
+  versionPattern = /^v\d+\.\d+\.\d+$/
 ): Promise<Record<string, GitHubTag>> {
   const tags: Record<string, GitHubTag> = {}
   for await (const tag of github.tagIterator()) {

--- a/actions/should-release/src/release.ts
+++ b/actions/should-release/src/release.ts
@@ -118,24 +118,34 @@ async function prepareSingleRelease(
 export function isLatestVersion(
   version: Version,
   tags: Record<string, GitHubTag>,
-  versionPattern: RegExp = /^v\d+\.\d+\.\d+$/
+  versionPattern = /^v\d+\.\d+\.\d+$/
 ): boolean {
-  info(`Checking if version ${version.toString()} is latest against ${Object.keys(tags).length} tags`)
-  
-  // Filter tags to only include those matching our version pattern
+  info(
+    `Checking if version ${version.toString()} is latest against ${
+      Object.keys(tags).length
+    } tags`
+  )
+
   const filteredTags = Object.entries(tags)
     .filter(([tagName]) => versionPattern.test(tagName))
-    .reduce((acc, [tagName, tag]) => {
-      acc[tagName] = tag
-      return acc
-    }, {} as Record<string, GitHubTag>)
-  
+    .reduce(
+      (acc, [tagName, tag]) => {
+        acc[tagName] = tag
+        return acc
+      },
+      {} as Record<string, GitHubTag>
+    )
+
   info(`Found ${Object.keys(filteredTags).length} matching version tags`)
-  
+
   for (const tag in filteredTags) {
     const tagVersion = Version.parse(tags[tag].name)
     const comparison = compareVersions(tagVersion, version)
-    info(`Comparing against tag ${tags[tag].name}: ${comparison > 0 ? 'newer' : 'older or equal'}`)
+    info(
+      `Comparing against tag ${tags[tag].name}: ${
+        comparison > 0 ? 'newer' : 'older or equal'
+      }`
+    )
     if (comparison > 0) {
       info(`Found newer version ${tags[tag].name}, marking as not latest`)
       return false


### PR DESCRIPTION
Latest workflow [run](https://github.com/grafana/loki/actions/runs/13283607213/job/37087375911) did not find `3.4.0` to be latest, due to the helm tags in the repository.  This restricts the lookup to be only loki (`vx.y.z`) tags.