### PR TITLE
fix: correct scope of loki make targets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -243,9 +243,8 @@
       "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check format"
-      "run": |
-        git fetch origin
-        make check-format
+      "run": "make check-format"
+      "working-directory": "release"
   "testLambdaPromtail":
     "container":
       "image": "${{ inputs.build_image }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -217,8 +217,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "fix git dubious ownership"
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -280,8 +283,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "fix git dubious ownership"
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -289,7 +295,7 @@
       "name": "test push package"
       "run": |
         gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-      "working-directory": "tools/lambda-promtail"
+      "working-directory": "release"
   "testPackages":
     "container":
       "image": "${{ inputs.build_image }}"
@@ -300,8 +306,11 @@
     - "collectPackages"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "fix git dubious ownership"
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -309,6 +318,7 @@
       "name": "test ${{ matrix.package }}"
       "run": |
         gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./${{ matrix.package }}/...
+      "working-directory": "release"
     "strategy":
       "matrix":
         "package": "${{fromJson(needs.collectPackages.outputs.packages)}}"
@@ -320,8 +330,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "fix git dubious ownership"
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -329,7 +342,7 @@
       "name": "test push package"
       "run": |
         gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-      "working-directory": "pkg/push"
+      "working-directory": "release"
 "name": "check"
 "on":
   "workflow_call":

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -243,7 +243,9 @@
       "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check format"
-      "run": "make check-format"
+      "run": |
+        git fetch origin
+        make check-format
       "working-directory": "release"
   "testLambdaPromtail":
     "container":

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,8 +32,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "pull release library code"
       "uses": "actions/checkout@v4"
       "with":
@@ -61,24 +64,31 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check generated files"
       "run": "make check-generated-files"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check mod"
       "run": "make check-mod"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check docs"
       "run": "make check-doc"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "validate example configs"
       "run": "make validate-example-configs"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "validate dev cluster config"
       "run": "make validate-dev-cluster-config"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check example config docs"
       "run": "make check-example-config-doc"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check helm reference doc"
       "run": "make documentation-helm-reference-check"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "build docs website"
       "run": |
@@ -95,6 +105,7 @@
           cp -r docs/sources/* /hugo/content/docs/loki/latest/
           cd /hugo && make prod
         EOF
+      "working-directory": "release"
   "collectPackages":
     "outputs":
       "packages": "${{ steps.gather-tests.outputs.packages }}"
@@ -161,8 +172,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "pull release library code"
       "uses": "actions/checkout@v4"
       "with":
@@ -194,6 +208,7 @@
         "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled"
         "only-new-issues": true
         "version": "${{ inputs.golang_ci_lint_version }}"
+      "working-directory": "release"
   "integration":
     "container":
       "image": "${{ inputs.build_image }}"
@@ -210,6 +225,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "integration"
       "run": "make test-integration"
+      "working-directory": "release"
   "lintFiles":
     "container":
       "image": "${{ inputs.build_image }}"
@@ -218,8 +234,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "pull release library code"
       "uses": "actions/checkout@v4"
       "with":
@@ -247,6 +266,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "lint scripts"
       "run": "make lint-scripts"
+      "working-directory": "release"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check format"
       "run": |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -171,6 +171,35 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "fix git dubious ownership"
+      "run": |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
+      "name": "install tar"
+      "run": |
+        apt update
+        apt install -qy tar xz-utils
+    - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
+      "name": "install shellcheck"
+      "uses": "./lib/actions/install-binary"
+      "with":
+        "binary": "shellcheck"
+        "download_url": "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz"
+        "smoke_test": "${binary} --version"
+        "tar_args": "xvf"
+        "tarball_binary_path": "*/${binary}"
+        "version": "0.9.0"
     - "name": "checkout"
       "uses": "actions/checkout@v4"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -171,35 +171,8 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "pull code to release"
+    - "name": "checkout"
       "uses": "actions/checkout@v4"
-      "with":
-        "path": "release"
-        "repository": "${{ env.RELEASE_REPO }}"
-    - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "lib"
-        "ref": "${{ env.RELEASE_LIB_REF }}"
-        "repository": "grafana/loki-release"
-    - "name": "fix git dubious ownership"
-      "run": |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
-      "name": "install tar"
-      "run": |
-        apt update
-        apt install -qy tar xz-utils
-    - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
-      "name": "install shellcheck"
-      "uses": "./lib/actions/install-binary"
-      "with":
-        "binary": "shellcheck"
-        "download_url": "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz"
-        "smoke_test": "${binary} --version"
-        "tar_args": "xvf"
-        "tarball_binary_path": "*/${binary}"
-        "version": "0.9.0"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "golangci-lint"
       "uses": "golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5"
@@ -207,7 +180,6 @@
         "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled"
         "only-new-issues": true
         "version": "${{ inputs.golang_ci_lint_version }}"
-        "working-directory": "release"
   "integration":
     "container":
       "image": "${{ inputs.build_image }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,8 +18,6 @@
     - "testPushPackage"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
-      "uses": "actions/checkout@v4"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "checks passed"
       "run": |
@@ -140,8 +138,6 @@
     - "testPushPackage"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
-      "uses": "actions/checkout@v4"
     - "name": "verify checks passed"
       "run": |
         echo "Some checks have failed!"
@@ -154,8 +150,11 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-latest"
     "steps":
-    - "name": "checkout"
+    - "name": "pull code to release"
       "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
     - "name": "fix git dubious ownership"
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -163,7 +162,7 @@
       "name": "faillint"
       "run": |
         faillint -paths "sync/atomic=go.uber.org/atomic" ./...
-        
+      "working-directory": "release"
   "golangciLint":
     "container":
       "image": "${{ inputs.build_image }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -209,7 +209,6 @@
         "only-new-issues": true
         "version": "${{ inputs.golang_ci_lint_version }}"
         "working-directory": "release"
-      "working-directory": "release"
   "integration":
     "container":
       "image": "${{ inputs.build_image }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -208,6 +208,7 @@
         "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled"
         "only-new-issues": true
         "version": "${{ inputs.golang_ci_lint_version }}"
+        "working-directory": "release"
       "working-directory": "release"
   "integration":
     "container":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -146,14 +146,14 @@ local validationJob = _validationJob(false);
   faillint:
     validationJob
     + job.withSteps([
-      common.checkout,
+      common.fetchReleaseRepo,
       common.fixDubiousOwnership,
       step.new('faillint')
       + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
       + step.withRun(|||
         faillint -paths "sync/atomic=go.uber.org/atomic" ./...
-
-      |||),
+      |||)
+      + step.withWorkingDirectory('release'),
     ]),
 
   golangciLint: setupValidationDeps(
@@ -203,7 +203,6 @@ local validationJob = _validationJob(false);
              })
              + job.withIf("${{ !fromJSON(inputs.skip_validation) && (cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) }}")
              + job.withSteps([
-               common.checkout,
                step.new('verify checks passed')
                + step.withRun(|||
                  echo "Some checks have failed!"
@@ -226,7 +225,6 @@ local validationJob = _validationJob(false);
            SKIP_VALIDATION: '${{ inputs.skip_validation }}',
          })
          + job.withSteps([
-           common.checkout,
            step.new('checks passed')
            + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
            + step.withRun(|||

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -58,7 +58,7 @@ local validationJob = _validationJob(false);
 
   integration: validationJob
                + job.withSteps([
-                 common.checkout,
+                 common.fetchReleaseRepo,
                  common.fixDubiousOwnership,
                  validationMakeStep('integration', 'test-integration'),
                ]),
@@ -71,38 +71,41 @@ local validationJob = _validationJob(false);
                   },
                 })
                 + job.withSteps([
-                  common.checkout,
+                  common.fetchReleaseRepo,
                   common.fixDubiousOwnership,
                   step.new('test ${{ matrix.package }}')
                   + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                   + step.withRun(|||
                     gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./${{ matrix.package }}/...
-                  |||),
+                  |||)
+                  + step.withWorkingDirectory('release'),
                 ]),
 
 
   testLambdaPromtail: validationJob
                       + job.withSteps([
-                        common.checkout,
+                        common.fetchReleaseRepo,
                         common.fixDubiousOwnership,
                         step.new('test push package')
                         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                         + step.withWorkingDirectory('tools/lambda-promtail')
                         + step.withRun(|||
                           gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-                        |||),
+                        |||)
+                        + step.withWorkingDirectory('release'),
                       ]),
 
   testPushPackage: validationJob
                    + job.withSteps([
-                     common.checkout,
+                     common.fetchReleaseRepo,
                      common.fixDubiousOwnership,
                      step.new('test push package')
                      + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                      + step.withWorkingDirectory('pkg/push')
                      + step.withRun(|||
                        gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-                     |||),
+                     |||)
+                     + step.withWorkingDirectory('release'),
                    ]),
 
   // Check / lint jobs

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -5,7 +5,7 @@ local _validationJob = common.validationJob;
 
 local setupValidationDeps = function(job) job {
   steps: [
-    common.checkout,
+    common.fetchReleaseRepo,
     common.fetchReleaseLib,
     common.fixDubiousOwnership,
     step.new('install tar')
@@ -33,7 +33,8 @@ local validationJob = _validationJob(false);
   local validationMakeStep = function(name, target)
     step.new(name)
     + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-    + step.withRun(common.makeTarget(target)),
+    + step.withRun(common.makeTarget(target))
+    + step.withWorkingDirectory('release'),
 
   // Test jobs
   collectPackages: job.new()
@@ -119,6 +120,7 @@ local validationJob = _validationJob(false);
       steps+: [
         step.new('build docs website')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
+        + step.withWorkingDirectory('release')
         + step.withRun(|||
           cat <<EOF | docker run \
             --interactive \
@@ -157,6 +159,7 @@ local validationJob = _validationJob(false);
       [
         step.new('golangci-lint', 'golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
+        + step.withWorkingDirectory('release')
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': true,

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -164,6 +164,7 @@ local validationJob = _validationJob(false);
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': true,
           args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
+          'working-directory': 'release',
         }),
       ],
     )

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -176,7 +176,13 @@ local validationJob = _validationJob(false);
     + job.withSteps(
       [
         validationMakeStep('lint scripts', 'lint-scripts'),
-        validationMakeStep('check format', 'check-format'),
+        step.new('check format')
+        + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
+        + step.withRun(|||
+          git fetch origin
+          make check-format
+        |||)
+        + step.withWorkingDirectory('release'),
       ]
     )
   ),

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -156,21 +156,20 @@ local validationJob = _validationJob(false);
       + step.withWorkingDirectory('release'),
     ]),
 
-  golangciLint: setupValidationDeps(
+  golangciLint:
     validationJob
     + job.withSteps(
       [
+        common.checkout,
         step.new('golangci-lint', 'golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': true,
           args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
-          'working-directory': 'release',
         }),
       ],
-    )
-  ),
+    ),
 
   lintFiles: setupValidationDeps(
     validationJob

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -159,7 +159,6 @@ local validationJob = _validationJob(false);
       [
         step.new('golangci-lint', 'golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-        + step.withWorkingDirectory('release')
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': true,

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -156,7 +156,7 @@ local validationJob = _validationJob(false);
       + step.withWorkingDirectory('release'),
     ]),
 
-  golangciLint:
+  golangciLint: setupValidationDeps(
     validationJob
     + job.withSteps(
       [
@@ -169,7 +169,8 @@ local validationJob = _validationJob(false);
           args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
         }),
       ],
-    ),
+    )
+  ),
 
   lintFiles: setupValidationDeps(
     validationJob

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -176,12 +176,7 @@ local validationJob = _validationJob(false);
     + job.withSteps(
       [
         validationMakeStep('lint scripts', 'lint-scripts'),
-        step.new('check format')
-        + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-        + step.withRun(|||
-          git fetch origin
-          make check-format
-        |||),
+        validationMakeStep('check format', 'check-format'),
       ]
     )
   ),


### PR DESCRIPTION
Inspired by https://github.com/grafana/loki/actions/runs/13420886614/job/37492970200?pr=16376, which showed the Loki shellcheck linting running against release code because it was being run from the root of the action pod workspace.