### PR TITLE
fix(build): Fix for the dist step

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -139,6 +139,9 @@ jobs:
           --entrypoint /bin/sh "grafana/loki-build-image:0.34.3"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
+          if echo "grafana/loki-build-image:0.34.3" | grep -q "golang"; then
+            /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+          fi
           make dist packages
         EOF
       working-directory: "release"

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -139,6 +139,9 @@ jobs:
           --entrypoint /bin/sh "grafana/loki-build-image:0.34.3"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
+          if echo "grafana/loki-build-image:0.34.3" | grep -q "golang"; then
+            /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+          fi
           make dist packages
         EOF
       working-directory: "release"

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -294,6 +294,11 @@ local runner = import 'runner.libsonnet',
       common.fetchReleaseRepo,
       common.googleAuth,
       common.setupGoogleCloudSdk,
+
+      releaseStep('install dependencies')
+      + step.withIf('${{ contains(\'%s\', \'golang\') }}' % buildImage)
+      + step.withRun('./workflows/install_workflow_dependencies.sh dist'),
+
       step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@main')
       + step.withId('get-secrets')
       + step.with({

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -335,7 +335,7 @@ local runner = import 'runner.libsonnet',
             --entrypoint /bin/sh "%s"
             git config --global --add safe.directory /src/loki
             echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-            if [[ "%s" == *"golang"* ]]; then
+            if echo "%s" | grep -q "golang"; then
               /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
             fi
             make %s

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -297,7 +297,7 @@ local runner = import 'runner.libsonnet',
 
       releaseStep('install dependencies')
       + step.withIf('${{ contains(\'%s\', \'golang\') }}' % buildImage)
-      + step.withRun('./workflows/install_workflow_dependencies.sh dist'),
+      + step.withRun('lib/workflows/install_workflow_dependencies.sh dist'),
 
       step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@main')
       + step.withId('get-secrets')

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -301,9 +301,12 @@ local runner = import 'runner.libsonnet',
       releaseStep('debug: list directory contents')
       + step.withRun('ls -la'),
 
+      releaseStep('debug: list .github directory contents')
+      + step.withRun('find .github -type f'),
+
       releaseStep('install dependencies')
       + step.withIf('${{ contains(\'%s\', \'golang\') }}' % buildImage)
-      + step.withRun('./workflows/install_workflow_dependencies.sh dist'),
+      + step.withRun('./.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist'),
 
       step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@main')
       + step.withId('get-secrets')

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -295,9 +295,15 @@ local runner = import 'runner.libsonnet',
       common.googleAuth,
       common.setupGoogleCloudSdk,
 
+      releaseStep('debug: print working directory')
+      + step.withRun('pwd'),
+
+      releaseStep('debug: list directory contents')
+      + step.withRun('ls -la'),
+
       releaseStep('install dependencies')
       + step.withIf('${{ contains(\'%s\', \'golang\') }}' % buildImage)
-      + step.withRun('release/workflows/install_workflow_dependencies.sh dist'),
+      + step.withRun('./workflows/install_workflow_dependencies.sh dist'),
 
       step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@main')
       + step.withId('get-secrets')

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -297,7 +297,7 @@ local runner = import 'runner.libsonnet',
 
       releaseStep('install dependencies')
       + step.withIf('${{ contains(\'%s\', \'golang\') }}' % buildImage)
-      + step.withRun('lib/workflows/install_workflow_dependencies.sh dist'),
+      + step.withRun('release/workflows/install_workflow_dependencies.sh dist'),
 
       step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@main')
       + step.withId('get-secrets')

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -16,6 +16,9 @@ install_dist_dependencies() {
 
     # Install FPM using gem
     gem install --no-document fpm
+
+    # Install RPM build tools
+    apt-get install -y rpm
 }
 
 # Update package lists

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -10,6 +10,14 @@ set -e
 # Set default source directory to GitHub workspace if not provided
 SRC_DIR=${SRC_DIR:-$GITHUB_WORKSPACE}
 
+install_dist_dependencies() {
+    # Install Ruby and development dependencies needed for FPM
+    apt-get install -y ruby ruby-dev rubygems build-essential
+
+    # Install FPM using gem
+    gem install --no-document fpm
+}
+
 # Update package lists
 apt-get update -qq
 
@@ -32,3 +40,8 @@ go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 
 # Update jsonnet bundles
 cd "${SRC_DIR}/.github" && jb update -q
+
+# Check if "dist" parameter is passed
+if [ "$1" = "dist" ]; then
+    install_dist_dependencies
+fi


### PR DESCRIPTION
Previously, the `dist` step was failing in GEL due to the removal of the enterprise-logs-build-image.  The new build image (a `golang` container) did not have fpm support.

Failing run: https://github.com/grafana/enterprise-logs/actions/runs/13446671228/job/37574044281

This PR updates the `dist` step to run the `install_workflow_dependencies.sh` script to install the needed items.  That script has also been enhanced to take a parameter, `dist`, that when provided, will install tooling only needed for the `dist` step (rpm, fpm, etc).  Longer term, we may want to tune this script to have even more granularity, but that is beyond the scope of this exercise.  
Furthermore, it is set to make this dependency installation optional, based on the build image provided.  This way, Loki, which uses `loki-build-image` will not run this, but GEL, which uses `golang` will run it.

GEL k242 was failing on the `dist` step (log above was taken from this branch).  After working on the changes, k242 is now passing, as evidenced here:
https://github.com/grafana/enterprise-logs/actions/runs/13663493817/job/38200584341

A subsequent PR will be opened to update the GEL repo to vendor in the new version of the `loki-release` library.