### PR TITLE
ci: workflow to close old PRs

### DIFF
--- a/.github/workflows/cleanup-old-release.yml
+++ b/.github/workflows/cleanup-old-release.yml
@@ -1,0 +1,96 @@
+name: Close Old PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Run at midnight every Monday
+
+  workflow_dispatch:
+    inputs:
+      pr_title_pattern:
+        description: 'Pattern to match PR titles (regex)'
+        required: true
+        default: '^chore\(weekly-'
+        type: string
+
+env:
+  USE_GITHUB_APP_TOKEN: true
+  PR_TITLE_PATTERN: ${{ github.event_name == 'schedule' && '^chore\(weekly-' || github.event.inputs.pr_title_pattern || '^chore\(weekly-' }}
+
+jobs:
+  cleanup-old-releases:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: get_github_app_token
+        if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
+        name: get github app token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: "${{ secrets.APP_ID }}"
+          owner: "${{ github.repository_owner }}"
+          private-key: "${{ secrets.APP_PRIVATE_KEY }}"
+
+      - id: github_app_token
+        name: set github token
+        run: |
+          if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
+            echo "token=${{ steps.get_github_app_token.outputs.token }}" >> $GITHUB_OUTPUT
+          else
+            echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Close old release PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const threeWeeksAgo = new Date();
+            threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 21);
+
+            let allPRs = [];
+            let page = 1;
+            let hasMore = true;
+
+            while (hasMore) {
+              const response = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                sort: 'created',
+                direction: 'desc',
+                per_page: 100,
+                page: page
+              });
+
+              allPRs = allPRs.concat(response.data);
+              hasMore = response.data.length === 100;
+              page++;
+            }
+
+            console.log(`Found ${allPRs.length} open PRs`);
+            console.log(`filtering by ${process.env.PR_TITLE_PATTERN}`);
+
+            let closedPrs = 0;
+            for (const pr of allPRs) {
+              if (new Date(pr.created_at) < threeWeeksAgo) { // older than 3 weeks ago
+                if (pr.title.match(new RegExp(process.env.PR_TITLE_PATTERN))) {
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    state: 'closed'
+                  });
+
+                  console.log(`Closed PR #${pr.number}: ${pr.title}`);
+                  closedPrs++;
+                }
+              }
+            }
+
+            console.log(`Closed ${closedPrs} old release PRs`);
+          github-token: ${{ steps.github_app_token.outputs.token }}


### PR DESCRIPTION
## Why?

This workflow will be an automation to clean up our release PRs that were created and not merged older than 3 weeks.
We are creating new versions of release PRs and not closing the old ones, that can cause mistakes from the team to rollouts and release process.

## What?

A new workflow that can be imported in any repo to close PRs.
The workflow is using the github app token as we do for release PR.
We run every Monday to continue the weekly process.
We defined the default regex for PR title `chore(weekly-`, but if needed during the manual trigger we can specify a custom expression.

*Notes*:

Nobody is using this workflow yet, so after merge this nothing should happen.
Only when we import the workflow in our enterprise-logs repo that will be used.