### PR TITLE
fix: remove redundant tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -293,10 +293,10 @@
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
-      "name": "test push package"
+      "name": "test lambda-promtail package"
       "run": |
         gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-      "working-directory": "release"
+      "working-directory": "release/tools/lambda-promtail"
   "testPackages":
     "container":
       "image": "${{ inputs.build_image }}"
@@ -343,7 +343,7 @@
       "name": "test push package"
       "run": |
         gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-      "working-directory": "release"
+      "working-directory": "release/pkg/push"
 "name": "check"
 "on":
   "workflow_call":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -86,13 +86,12 @@ local validationJob = _validationJob(false);
                       + job.withSteps([
                         common.fetchReleaseRepo,
                         common.fixDubiousOwnership,
-                        step.new('test push package')
+                        step.new('test lambda-promtail package')
                         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-                        + step.withWorkingDirectory('tools/lambda-promtail')
+                        + step.withWorkingDirectory('release/tools/lambda-promtail')
                         + step.withRun(|||
                           gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-                        |||)
-                        + step.withWorkingDirectory('release'),
+                        |||),
                       ]),
 
   testPushPackage: validationJob
@@ -101,11 +100,10 @@ local validationJob = _validationJob(false);
                      common.fixDubiousOwnership,
                      step.new('test push package')
                      + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-                     + step.withWorkingDirectory('pkg/push')
+                     + step.withWorkingDirectory('release/pkg/push')
                      + step.withRun(|||
                        gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-                     |||)
-                     + step.withWorkingDirectory('release'),
+                     |||),
                    ]),
 
   // Check / lint jobs


### PR DESCRIPTION
A mistake in the jsonnet was overwriting the working directory for the `testLambdaPromtail` and `testPushPackage` tests, causing them to be run from the root directory, effectively running ALL THE TESTS in Loki 😱 

This fixes that.