### PR TITLE
fix: Add go mod tify step to testPushPackage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -340,6 +340,11 @@
       "run": |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
+      "name": "go mod tidy"
+      "run": |
+        go mod tidy
+      "working-directory": "release/pkg/push"
+    - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "test push package"
       "run": |
         gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -98,6 +98,12 @@ local validationJob = _validationJob(false);
                    + job.withSteps([
                      common.fetchReleaseRepo,
                      common.fixDubiousOwnership,
+                     step.new('go mod tidy')
+                     + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
+                     + step.withWorkingDirectory('release/pkg/push')
+                     + step.withRun(|||
+                       go mod tidy
+                     |||),
                      step.new('test push package')
                      + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                      + step.withWorkingDirectory('release/pkg/push')


### PR DESCRIPTION
The Ci is failing: https://github.com/grafana/loki/actions/runs/14230955463/job/39881345947

Running go mod tidy locally doesn't yield any change, so we are adding it as a step to the failing workflow.