### PR TITLE
chore(build): Remove hardcoded workflow library reference

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,8 @@
 "concurrency":
   "group": "check-${{ github.sha }}"
 "env":
-  "RELEASE_LIB_REF": "06e329f48326e249aeb36d340130a39504575815"
+  "RELEASE_LIB_REF": "${{ inputs.release_lib_ref }}"
+  "USE_GITHUB_APP_TOKEN": "${{ inputs.use_github_app_token }}"
 "jobs":
   "check":
     "env":

--- a/workflows/workflows.jsonnet
+++ b/workflows/workflows.jsonnet
@@ -65,11 +65,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
     }, false, false
   ),
   '.github/workflows/check.yml': std.manifestYamlDoc(
-    lokiRelease.check + { // TODO: Remove this once we have a stable release lib ref
-      env: {
-        RELEASE_LIB_REF: '06e329f48326e249aeb36d340130a39504575815',
-      },
-    }
+    lokiRelease.check
   ),
   '.github/workflows/gel-check.yml': std.manifestYamlDoc(
     lokiRelease.checkGel


### PR DESCRIPTION
Follow on PR to https://github.com/grafana/loki-release/pull/233

Removes hardcoded library reference, now that the scripts are in `main`