### PR TITLE
ci: set github app as environment variable

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -6,6 +6,7 @@ env:
   CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   DRY_RUN: false
+  GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "trevorwhitney075"
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki-release"
@@ -62,8 +63,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
@@ -374,8 +375,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ concurrency:
   group: "create-release-${{ github.sha }}"
 env:
   BUILD_ARTIFACTS_BUCKET: "loki-build-artifacts"
+  GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "trevorwhitney075"
   PUBLISH_TO_GCS: false
   RELEASE_LIB_REF: "main"
@@ -57,8 +58,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
@@ -162,8 +163,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
@@ -349,8 +350,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -6,6 +6,7 @@ env:
   CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   DRY_RUN: true
+  GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "trevorwhitney075"
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki-release"
@@ -62,8 +63,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
@@ -374,8 +375,8 @@ jobs:
       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       with:
         repo_secrets: |
-          APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key
+          APP_ID=${{ env.GITHUB_APP }}:app-id
+          PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"

--- a/workflows/common.libsonnet
+++ b/workflows/common.libsonnet
@@ -140,8 +140,8 @@
                        + $.step.withIf('${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}')
                        + $.step.with({
                          repo_secrets: |||
-                           APP_ID=loki-gh-app:app-id
-                           PRIVATE_KEY=loki-gh-app:private-key
+                           APP_ID=${{ env.GITHUB_APP }}:app-id
+                           PRIVATE_KEY=${{ env.GITHUB_APP }}:private-key
                          |||,
                        }),
   githubAppToken: $.step.new('get github app token', 'actions/create-github-app-token@v1')

--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -27,6 +27,7 @@
     useGitHubAppToken=true,
     useGCR=false,
     versioningStrategy='always-bump-patch',
+    githubApp='loki-gh-app',
                     ) {
     name: 'create release PR',
     on: {
@@ -53,6 +54,7 @@
       SKIP_VALIDATION: skipValidation,
       USE_GITHUB_APP_TOKEN: useGitHubAppToken,
       VERSIONING_STRATEGY: versioningStrategy,
+      GITHUB_APP: githubApp,
     } + if releaseAs != null then {
       RELEASE_AS: releaseAs,
     } else {},
@@ -103,6 +105,7 @@
     useGitHubAppToken=true,
     dockerPluginPath='clients/cmd/docker-driver',
     publishDockerPlugins=true,
+    githubApp='loki-gh-app',
                   ) {
     name: 'create release',
     on: {
@@ -123,6 +126,7 @@
       RELEASE_LIB_REF: releaseLibRef,
       RELEASE_REPO: releaseRepo,
       USE_GITHUB_APP_TOKEN: useGitHubAppToken,
+      GITHUB_APP: githubApp,
     } + if publishToGCS then {
       PUBLISH_BUCKET: publishBucket,
       PUBLISH_TO_GCS: true,

--- a/workflows/workflows.jsonnet
+++ b/workflows/workflows.jsonnet
@@ -20,6 +20,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
+      githubApp='loki-gh-app',
     ) + {
       name: 'Create Release PR',
     }, false, false
@@ -39,6 +40,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
+      githubApp='loki-gh-app',
     ) + {
       name: 'Test Create Release PR Action',
       on+: {
@@ -57,6 +59,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       releaseLibRef='main',
       releaseRepo='grafana/loki-release',
       useGitHubAppToken=true,
+      githubApp='loki-gh-app',
     ) + {
       name: 'Create Release',
       on+: {


### PR DESCRIPTION
## Why?

Setting the github app name configurable as environment variable to be used in multiple repos with different app names.