### PR TITLE
fix: create release pr trigger

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -455,6 +455,7 @@ name: "Create Release PR"
   push:
     branches:
     - "release-[0-9]+.[0-9]+.x"
+  workflow_dispatch: {}
 permissions:
   contents: "read"
   pull-requests: "read"

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -456,6 +456,7 @@ name: "Test Create Release PR Action"
   push:
     branches:
     - "release-[0-9]+.[0-9]+.x"
+  workflow_dispatch: {}
 permissions:
   contents: "read"
   pull-requests: "read"

--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -6,6 +6,7 @@
   release: import 'release.libsonnet',
   validate: import 'validate.libsonnet',
   validateGel: import 'validate-gel.libsonnet',
+
   releasePRWorkflow: function(
     branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+'],
     buildArtifactsBucket='loki-build-artifacts',
@@ -34,6 +35,7 @@
       push: {
         branches: branches,
       },
+      workflow_dispatch: {},
     },
     permissions: {
       contents: 'read',


### PR DESCRIPTION
## Why?

Add a manual trigger to create a release pr in case we need to retry the workflow after miss the `fix` naming