### PR TITLE
fix: publishing docker plugins needs the GHA token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,8 @@ jobs:
   publishDockerPlugins:
     needs:
     - "createRelease"
+    permissions:
+      id-token: "write"
     runs-on: "ubuntu-latest"
     steps:
     - name: "pull release library code"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -220,6 +220,9 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
   publishDockerPlugins: function(path, getDockerCredsFromVault=false, dockerUsername='grafanabot')
     job.new()
     + job.withNeeds(['createRelease'])
+    + job.withPermissions({
+      'id-token': 'write',
+    })
     + job.withSteps(
       [
         common.fetchReleaseLib,


### PR DESCRIPTION
publish docker plugins needs to login to docker, which requires vault, which require `id-token: write`