### PR TITLE
chore: Set `only-new-issues` in golangci-lint check to `false`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -232,7 +232,7 @@
       "uses": "golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5"
       "with":
         "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled,slicelabels"
-        "only-new-issues": true
+        "only-new-issues": false
         "version": "${{ inputs.golang_ci_lint_version }}"
   "integration":
     "container":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -190,7 +190,7 @@ local validationJob = _validationJob(false);
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
-          'only-new-issues': true,
+          'only-new-issues': false,  // we want a PR to fail if the target branch fails
           args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled,slicelabels',
         }),
       ],


### PR DESCRIPTION
We want PRs to fail this check if the check on the target branch also fails.