### PR TITLE
chore: Revert "refactor: Add slicelabels to check workflow (#265)"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -179,7 +179,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "faillint"
       "run": |
-        GOFLAGS="-tags=slicelabels" faillint -paths "sync/atomic=go.uber.org/atomic" ./...
+        faillint -paths "sync/atomic=go.uber.org/atomic" ./...
       "working-directory": "release"
   "golangciLint":
     "container":
@@ -231,7 +231,7 @@
       "name": "golangci-lint"
       "uses": "golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5"
       "with":
-        "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled,slicelabels"
+        "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled"
         "only-new-issues": false
         "version": "${{ inputs.golang_ci_lint_version }}"
   "integration":
@@ -337,7 +337,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "test lambda-promtail package"
       "run": |
-        gotestsum -- -tags slicelabels -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
+        gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
       "working-directory": "release/tools/lambda-promtail"
   "testPackages":
     "container":
@@ -372,7 +372,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "test ${{ matrix.package }}"
       "run": |
-        gotestsum -- -tags slicelabels -covermode=atomic -coverprofile=coverage.txt -p=4 ./${MATRIX_PACKAGE}/...
+        gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./${MATRIX_PACKAGE}/...
       "working-directory": "release"
     "strategy":
       "matrix":
@@ -412,7 +412,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "test push package"
       "run": |
-        gotestsum -- -tags slicelabels -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
+        gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
       "working-directory": "release/pkg/push"
 "name": "check"
 "on":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -86,7 +86,7 @@ local validationJob = _validationJob(false);
                   step.new('test ${{ matrix.package }}')
                   + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                   + step.withRun(|||
-                    gotestsum -- -tags slicelabels -covermode=atomic -coverprofile=coverage.txt -p=4 ./${MATRIX_PACKAGE}/...
+                    gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./${MATRIX_PACKAGE}/...
                   |||)
                   + step.withWorkingDirectory('release'),
                 ]),
@@ -103,7 +103,7 @@ local validationJob = _validationJob(false);
                         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                         + step.withWorkingDirectory('release/tools/lambda-promtail')
                         + step.withRun(|||
-                          gotestsum -- -tags slicelabels -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
+                          gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
                         |||),
                       ]),
 
@@ -125,7 +125,7 @@ local validationJob = _validationJob(false);
                      + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                      + step.withWorkingDirectory('release/pkg/push')
                      + step.withRun(|||
-                       gotestsum -- -tags slicelabels -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
+                       gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
                      |||),
                    ]),
 
@@ -176,7 +176,7 @@ local validationJob = _validationJob(false);
       step.new('faillint')
       + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
       + step.withRun(|||
-        GOFLAGS="-tags=slicelabels" faillint -paths "sync/atomic=go.uber.org/atomic" ./...
+        faillint -paths "sync/atomic=go.uber.org/atomic" ./...
       |||)
       + step.withWorkingDirectory('release'),
     ]),
@@ -191,7 +191,7 @@ local validationJob = _validationJob(false);
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': false,  // we want a PR to fail if the target branch fails
-          args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled,slicelabels',
+          args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
         }),
       ],
     )


### PR DESCRIPTION
We should use the new `stringlabels` since https://github.com/grafana/loki/pull/18490 was merged