### PR TITLE
feat: Add linux/riscv64 to platform map

### DIFF
--- a/workflows/runner.libsonnet
+++ b/workflows/runner.libsonnet
@@ -2,6 +2,7 @@ local defaultMapping = {
   'linux/amd64': ['github-hosted-ubuntu-x64-small'],
   'linux/arm64': ['github-hosted-ubuntu-arm64-small'],
   'linux/arm': ['github-hosted-ubuntu-arm64-small'],  // equal to linux/arm/v7
+  'linux/riscv64': ['ubuntu-26.04-riscv'],  // https://github.com/apps/rise-risc-v-runners
 };
 
 {


### PR DESCRIPTION
This does not change any workflows, but allows for selecting a runner when building for RISC-V architecture.