### PR TITLE
chore: Remove step for cleaning up runner build cache

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -123,8 +123,6 @@ jobs:
       pull-requests: "write"
     runs-on: "ubuntu-26.04"
     steps:
-    - name: "clean up build tools cache"
-      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -123,8 +123,6 @@ jobs:
       pull-requests: "write"
     runs-on: "ubuntu-latest"
     steps:
-    - name: "clean up build tools cache"
-      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -321,7 +321,6 @@ local runner = import 'runner.libsonnet',
       'id-token': 'write',
     })
     + job.withSteps([
-      common.cleanUpBuildCache,
       common.fetchReleaseRepo,
       common.fetchGcsCredentials,
       common.googleAuth,


### PR DESCRIPTION
This step does not have sufficient permissions and fails.