### PR TITLE
ci: Move to self-hosted runners

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@
     - "integration"
     - "testPackages"
     - "testPushPackage"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "checks passed"
@@ -27,7 +27,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"
@@ -111,7 +111,7 @@
   "collectPackages":
     "outputs":
       "packages": "${{ steps.gather-tests.outputs.packages }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "checkout"
       "uses": "actions/checkout@v4"
@@ -141,7 +141,7 @@
     - "integration"
     - "testPackages"
     - "testPushPackage"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "verify checks passed"
       "run": |
@@ -153,7 +153,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"
@@ -185,7 +185,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"
@@ -238,7 +238,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"
@@ -259,7 +259,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"
@@ -314,7 +314,7 @@
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "needs":
     - "collectPackages"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"
@@ -349,7 +349,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "pull code to release"
       "uses": "actions/checkout@v4"

--- a/.github/workflows/gel-check.yml
+++ b/.github/workflows/gel-check.yml
@@ -10,7 +10,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "checkout"
       "uses": "actions/checkout@v4"
@@ -76,7 +76,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "checkout"
       "uses": "actions/checkout@v4"
@@ -127,7 +127,7 @@
     "env":
       "BUILD_IN_CONTAINER": false
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "checkout"
       "uses": "actions/checkout@v4"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write
@@ -38,7 +38,7 @@ jobs:
       - run: npm install
       - run: npm run lint
   actions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write
@@ -75,7 +75,7 @@ jobs:
           git diff --name-only -- "actions/**/*.js" | xargs --no-run-if-empty git diff --exit-code -- \
             || (echo "Change to actions detected, please run 'npm run actions' and commit the changes" && false)
   workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write
@@ -93,7 +93,7 @@ jobs:
           git diff --name-only -w -- ".github/workflows/*.yml" | xargs --no-run-if-empty git diff -w --exit-code -- \
             || (echo "Change to workflows detected, please run 'npm run workflows' and commit the changes" && false)
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write
@@ -131,7 +131,7 @@ jobs:
       - run: npm install
       - run: npm run ci-test
   check-title:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,7 +35,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -392,7 +392,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -151,7 +151,7 @@ jobs:
     permissions:
       contents: "write"
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -248,7 +248,7 @@ jobs:
     - "createRelease"
     permissions:
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -310,7 +310,7 @@ jobs:
     - "createRelease"
     permissions:
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -368,7 +368,7 @@ jobs:
     permissions:
       contents: "write"
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -423,7 +423,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -35,7 +35,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -121,7 +121,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -379,7 +379,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"

--- a/workflows/build.libsonnet
+++ b/workflows/build.libsonnet
@@ -315,7 +315,7 @@ local runner = import 'runner.libsonnet',
       pr_created: '${{ steps.version.outputs.pr_created }}',
     }),
 
-  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-latest')
+  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-x64')
     job.new(runsOn)
     + job.withPermissions({
       'id-token': 'write',

--- a/workflows/common.libsonnet
+++ b/workflows/common.libsonnet
@@ -34,7 +34,7 @@
     },
   },
   job: {
-    new: function(runsOn='ubuntu-latest') {
+    new: function(runsOn='ubuntu-x64') {
       'runs-on': runsOn,
     },
     with: function(with) {

--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -15,7 +15,7 @@
     checkTemplate='./.github/workflows/check.yml',
     distMakeTargets=['dist', 'packages'],
     distOptionalTargets=[],
-    distRunsOn='ubuntu-latest',
+    distRunsOn='ubuntu-x64',
     dryRun=false,
     dockerUsername='grafana',
     golangCiLintVersion='v2.3.0',

--- a/workflows/runner.libsonnet
+++ b/workflows/runner.libsonnet
@@ -28,6 +28,6 @@ local defaultMapping = {
     }
     else {
       arch: arch,
-      runs_on: ['ubuntu-latest'],
+      runs_on: ['ubuntu-x64'],
     },
 }


### PR DESCRIPTION
`ubuntu-latest` are not self-hosted workers.

Ref: https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/#use-self-hosted-runners