### PR TITLE
ci: Move away from github hosted runners

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -281,13 +281,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-docker-driver:
     needs:
     - "version"
@@ -378,10 +378,10 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   version:
     needs:
     - "check"

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -268,13 +268,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-docker-driver:
     needs:
     - "version"
@@ -365,10 +365,10 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   version:
     needs:
     - "check"

--- a/workflows/runner.libsonnet
+++ b/workflows/runner.libsonnet
@@ -1,7 +1,7 @@
 local defaultMapping = {
-  'linux/amd64': ['github-hosted-ubuntu-x64-small'],
-  'linux/arm64': ['github-hosted-ubuntu-arm64-small'],
-  'linux/arm': ['github-hosted-ubuntu-arm64-small'],  // equal to linux/arm/v7
+  'linux/amd64': ['ubuntu-x64'],
+  'linux/arm64': ['ubuntu-arm64'],
+  'linux/arm': ['ubuntu-arm64'],  // equal to linux/arm/v7
   'linux/riscv64': ['ubuntu-26.04-riscv'],  // https://github.com/apps/rise-risc-v-runners
 };
 


### PR DESCRIPTION
Move to self-hosted versions of these runners, also bumping the shape to the default, which will hopefully help build times. 

Self hosted shapes:
small (2 vCPU and 8 GiB of RAM)
default (4 vCPU and 16 GiB of RAM)