### PR TITLE
fix: Don't assume that this working directory has an origin or a main branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -258,6 +258,7 @@
       "image": "${{ inputs.build_image }}"
     "env":
       "BUILD_IN_CONTAINER": false
+      "GIT_TARGET_BRANCH": "${{ vars.GIT_TARGET_BRANCH }}"
       "SKIP_VALIDATION": "${{ inputs.skip_validation }}"
     "runs-on": "ubuntu-x64"
     "steps":
@@ -302,7 +303,7 @@
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "check format"
       "run": |
-        git fetch origin
+        git fetch https://github.com/grafana/loki.git main:refs/remotes/origin/${GIT_TARGET_BRANCH:-main}
         make check-format
       "working-directory": "release"
   "testPackages":

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -304,7 +304,7 @@
       "name": "check format"
       "run": |
         git fetch https://github.com/grafana/loki.git main:refs/remotes/origin/${GIT_TARGET_BRANCH:-main}
-        make check-format
+        GIT_TARGET_BRANCH="${GIT_TARGET_BRANCH:-main}" make check-format
       "working-directory": "release"
   "testPackages":
     "container":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -183,13 +183,16 @@ local validationJob = _validationJob(false);
 
   lintFiles: setupValidationDeps(
     validationJob
+    + job.withEnv({
+      GIT_TARGET_BRANCH: '${{ vars.GIT_TARGET_BRANCH }}',
+    })
     + job.withSteps(
       [
         validationMakeStep('lint scripts', 'lint-scripts'),
         step.new('check format')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
         + step.withRun(|||
-          git fetch origin
+          git fetch https://github.com/grafana/loki.git main:refs/remotes/origin/${GIT_TARGET_BRANCH:-main}
           make check-format
         |||)
         + step.withWorkingDirectory('release'),

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -193,7 +193,7 @@ local validationJob = _validationJob(false);
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
         + step.withRun(|||
           git fetch https://github.com/grafana/loki.git main:refs/remotes/origin/${GIT_TARGET_BRANCH:-main}
-          make check-format
+          GIT_TARGET_BRANCH="${GIT_TARGET_BRANCH:-main}" make check-format
         |||)
         + step.withWorkingDirectory('release'),
       ]


### PR DESCRIPTION
In `loki-private`, the CI fails because it can't `fetch origin`.

`check.yaml` assumes there is a remote called `origin` which is fetchable, and that there is a `main` branch containing the latest `loki` code.

None of that turns out to be true in `loki-private`.

Using this syntax to fetch directly from the root repo should enable the the CI to work on a fork.

Specifying `GIT_TARGET_BRANCH` allows using a new branch name so as not to conflict with the fork `main` which (in this case) has diverged from the root repo.

This value _should_ flow into `make` and be picked up by the `check-format` target
