### PR TITLE
ci: Add more tools to the workflow dependencies script

### DIFF
--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -108,11 +108,19 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
 apt-get update
 apt-get install -y docker-ce-cli docker-buildx-plugin
 
-# jsonnet CLI plus ragel / protoc (parity with grafana/loki loki-build-image)
-apt-get install -qq -y jsonnet ragel protobuf-compiler libprotobuf-dev
+# jsonnet CLI plus ragel
+apt-get install -qq -y jsonnet ragel
 
 # Install jsonnet-bundler
 go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+
+# Install protoc
+# Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.
+# If we don't force this, Go is going to default to GOPATH mode as we do not have an active project or go.mod
+# file for it to detect and switch to Go Modules automatically.
+# It's possible this can be revisited in newer versions of Go if the behavior around GOPATH vs GO111MODULES changes
+RUN GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.1
+RUN GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0
 
 # Update jsonnet bundles
 if [ -d "${SRC_DIR}/.github" ]; then

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -74,7 +74,7 @@ install_build_image_tools() {
     curl -fsSL -o /usr/local/bin/buf \
         "https://github.com/bufbuild/buf/releases/download/${BUF_VER}/buf-Linux-${BUF_ARCH}"
     chmod 0755 /usr/local/bin/buf
-    apt-get install -y protobuf-compiler libprotobuf-dev
+    apt-get install -y protobuf-compiler libprotobuf-dev ragel
 
     # Install protoc
     # Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.
@@ -117,8 +117,8 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
 apt-get update
 apt-get install -y docker-ce-cli docker-buildx-plugin
 
-# Install jsonnet CLI plus ragel
-apt-get install -qq -y jsonnet ragel
+# Install jsonnet
+apt-get install -qq -y jsonnet
 
 # Install jsonnet-bundler
 go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -6,9 +6,15 @@ set -e
 # "golang" container.
 # It houses all of the dependencies for the workflows, as well as the dependencies
 # needed for the make release-workflows target.
+#
+# Optional arguments (combinable): dist, lint, loki-release.
+# Environment: GOLANGCI_LINT_VERSION for lint (default v2.10.1); LYCHEE_VER; BUF_VER.
 
 # Set default source directory to GitHub workspace if not provided
 SRC_DIR=${SRC_DIR:-${GITHUB_WORKSPACE}}
+
+# golangci-lint version (e.g. v2.10.1). Override when invoking with the "lint" mode.
+GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION:-v2.10.1}
 
 # Debug information
 echo "Current directory: $(pwd)"
@@ -24,6 +30,50 @@ install_dist_dependencies() {
 
     # Install RPM build tools
     apt-get install -y rpm
+}
+
+install_lint_dependencies() {
+    echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}"
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh |
+        sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
+}
+
+install_build_image_tools() {
+    # Versions aligned with grafana/loki loki-build-image Dockerfile where applicable.
+    LYCHEE_VER=${LYCHEE_VER:-0.7.0}
+    BUF_VER=${BUF_VER:-v1.4.0}
+
+    echo "Installing mixtool and goyacc"
+    GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@16dc166166d91e93475b86b9355a4faed2400c18
+    GO111MODULE=on go install golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69
+
+    MACHINE=$(uname -m)
+    case "${MACHINE}" in
+        x86_64)
+            LYCHEE_ARCH=x86_64-unknown-linux-gnu
+            BUF_ARCH=x86_64
+            ;;
+        aarch64)
+            LYCHEE_ARCH=aarch64-unknown-linux-gnu
+            BUF_ARCH=aarch64
+            ;;
+        *)
+            echo "Unsupported machine for lychee/buf downloads: ${MACHINE}" >&2
+            exit 1
+            ;;
+    esac
+
+    echo "Installing lychee ${LYCHEE_VER}"
+    curl -fsSL -o /tmp/lychee.tgz \
+        "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VER}/lychee-${LYCHEE_VER}-${LYCHEE_ARCH}.tar.gz"
+    tar -xz -C /tmp -f /tmp/lychee.tgz
+    install -m 0755 /tmp/lychee /usr/local/bin/lychee
+    rm -f /tmp/lychee.tgz
+
+    echo "Installing buf ${BUF_VER}"
+    curl -fsSL -o /usr/local/bin/buf \
+        "https://github.com/bufbuild/buf/releases/download/${BUF_VER}/buf-Linux-${BUF_ARCH}"
+    chmod 0755 /usr/local/bin/buf
 }
 
 install_loki_release_dependencies() {
@@ -58,8 +108,8 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
 apt-get update
 apt-get install -y docker-ce-cli docker-buildx-plugin
 
-# Install jsonnet
-apt-get install -qq -y jsonnet
+# jsonnet CLI plus ragel / protoc (parity with grafana/loki loki-build-image)
+apt-get install -qq -y jsonnet ragel protobuf-compiler libprotobuf-dev
 
 # Install jsonnet-bundler
 go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
@@ -71,10 +121,23 @@ else
     echo "Warning: ${SRC_DIR}/.github directory not found, skipping jsonnet bundle update"
 fi
 
-# Check if "dist" parameter is passed
-if [ "$1" = "dist" ]; then
-    install_dist_dependencies
-fi
-if [ "$1" = "loki-release" ]; then
-    install_loki_release_dependencies
-fi
+install_build_image_tools
+
+# Optional modes (any combination, e.g. "dist lint")
+for arg in "$@"; do
+    case "${arg}" in
+        dist)
+            install_dist_dependencies
+            ;;
+        lint)
+            install_lint_dependencies
+            ;;
+        loki-release)
+            install_loki_release_dependencies
+            ;;
+        *)
+            echo "Unknown install mode: ${arg}" >&2
+            exit 1
+            ;;
+    esac
+done

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -136,12 +136,12 @@ for arg in "$@"; do
         dist)
             install_dist_dependencies
             ;;
-        lint)
-            install_lint_dependencies
-            ;;
         loki-release)
             install_loki_release_dependencies
             ;;
+        lint)
+            install_lint_dependencies
+            ;;    
         loki-build-tools)
             install_build_image_tools
         *)

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -7,7 +7,7 @@ set -e
 # It houses all of the dependencies for the workflows, as well as the dependencies
 # needed for the make release-workflows target.
 #
-# Optional arguments (combinable): dist, lint, loki-release.
+# Optional arguments (combinable): dist, lint, loki-release, loki-build-tools.
 # Environment: GOLANGCI_LINT_VERSION for lint (default v2.10.1); LYCHEE_VER; BUF_VER.
 
 # Set default source directory to GitHub workspace if not provided

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -74,6 +74,7 @@ install_build_image_tools() {
     curl -fsSL -o /usr/local/bin/buf \
         "https://github.com/bufbuild/buf/releases/download/${BUF_VER}/buf-Linux-${BUF_ARCH}"
     chmod 0755 /usr/local/bin/buf
+    apt-get install -y protobuf-compiler libprotobuf-dev
 
     # Install protoc
     # Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.
@@ -116,7 +117,7 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
 apt-get update
 apt-get install -y docker-ce-cli docker-buildx-plugin
 
-# jsonnet CLI plus ragel
+# Install jsonnet CLI plus ragel
 apt-get install -qq -y jsonnet ragel
 
 # Install jsonnet-bundler

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -130,8 +130,6 @@ else
     echo "Warning: ${SRC_DIR}/.github directory not found, skipping jsonnet bundle update"
 fi
 
-install_build_image_tools
-
 # Optional modes (any combination, e.g. "dist lint")
 for arg in "$@"; do
     case "${arg}" in
@@ -144,6 +142,8 @@ for arg in "$@"; do
         loki-release)
             install_loki_release_dependencies
             ;;
+        loki-build-tools)
+            install_build_image_tools
         *)
             echo "Unknown install mode: ${arg}" >&2
             exit 1

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -74,6 +74,14 @@ install_build_image_tools() {
     curl -fsSL -o /usr/local/bin/buf \
         "https://github.com/bufbuild/buf/releases/download/${BUF_VER}/buf-Linux-${BUF_ARCH}"
     chmod 0755 /usr/local/bin/buf
+
+    # Install protoc
+    # Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.
+    # If we don't force this, Go is going to default to GOPATH mode as we do not have an active project or go.mod
+    # file for it to detect and switch to Go Modules automatically.
+    # It's possible this can be revisited in newer versions of Go if the behavior around GOPATH vs GO111MODULES changes
+    GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.1
+    GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0
 }
 
 install_loki_release_dependencies() {
@@ -113,14 +121,6 @@ apt-get install -qq -y jsonnet ragel
 
 # Install jsonnet-bundler
 go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
-
-# Install protoc
-# Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.
-# If we don't force this, Go is going to default to GOPATH mode as we do not have an active project or go.mod
-# file for it to detect and switch to Go Modules automatically.
-# It's possible this can be revisited in newer versions of Go if the behavior around GOPATH vs GO111MODULES changes
-RUN GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.1
-RUN GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0
 
 # Update jsonnet bundles
 if [ -d "${SRC_DIR}/.github" ]; then

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -144,6 +144,7 @@ for arg in "$@"; do
             ;;    
         loki-build-tools)
             install_build_image_tools
+            ;;
         *)
             echo "Unknown install mode: ${arg}" >&2
             exit 1


### PR DESCRIPTION
This PR adds two new available targets: `lint` and `loki-build-tools`.

`lint` is to install the `golangci-lint` binary, and the version can be specified via an environment variable.
`loki-build-tools` are items needed for various targets in the Loki Makefile, which are also contained within the `loki-build-tools` image.

The goal of this PR is to ensure all Loki Makefile targets can be supported with a generic image, as opposed to the custom-made `loki-build-image`.

This PR also reorganizes how this is invoked, and allows multiple targets to be specifed.


In support of: https://github.com/grafana/loki-release/issues/177