### PR TITLE
ci: Call loki-build-tools as part of the check process

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,7 +47,7 @@
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) && startsWith(inputs.build_image, 'golang') }}"
       "name": "install dependencies"
-      "run": "lib/workflows/install_workflow_dependencies.sh loki-release"
+      "run": "lib/workflows/install_workflow_dependencies.sh loki-release loki-build-tools"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "install tar"
       "run": |
@@ -205,7 +205,7 @@
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) && startsWith(inputs.build_image, 'golang') }}"
       "name": "install dependencies"
-      "run": "lib/workflows/install_workflow_dependencies.sh loki-release"
+      "run": "lib/workflows/install_workflow_dependencies.sh loki-release loki-build-tools"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "install tar"
       "run": |
@@ -280,7 +280,7 @@
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) && startsWith(inputs.build_image, 'golang') }}"
       "name": "install dependencies"
-      "run": "lib/workflows/install_workflow_dependencies.sh loki-release"
+      "run": "lib/workflows/install_workflow_dependencies.sh loki-release loki-build-tools"
     - "if": "${{ !fromJSON(env.SKIP_VALIDATION) }}"
       "name": "install tar"
       "run": |

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -10,7 +10,7 @@ local setupValidationDeps = function(job) job {
     common.fixDubiousOwnership,
     step.new('install dependencies')
     + step.withIf("${{ !fromJSON(env.SKIP_VALIDATION) && startsWith(inputs.build_image, 'golang') }}")
-    + step.withRun('lib/workflows/install_workflow_dependencies.sh loki-release'),
+    + step.withRun('lib/workflows/install_workflow_dependencies.sh loki-release loki-build-tools'),
     step.new('install tar')
     + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
     + step.withRun(|||


### PR DESCRIPTION
As evidenced in this [run](https://github.com/grafana/loki/actions/runs/24856594299/job/72770936887), the `checkFiles` step needs the `buf` tool.  

This PR adjusts the parameters for that step to include the tooling brought in with [this](https://github.com/grafana/loki-release/pull/306) PR