### PR TITLE
fix(should-release): scan PR body as a fallback when the footer is displaced

### DIFF
--- a/actions/should-release/__tests__/release.test.ts
+++ b/actions/should-release/__tests__/release.test.ts
@@ -102,8 +102,22 @@ describe('release', () => {
           name: 'v1.3.1',
           sha: 'abs123'
         } as GitHubTag
-      }
+      },
+      bodySuffix = ''
     ): void => {
+      const body =
+        new PullRequestBody(
+          [
+            {
+              version: defaultNextVersion,
+              notes: defaultPRNotes
+            }
+          ],
+          {
+            footer
+          }
+        ).toString() + bodySuffix
+
       findMergedReleasePullRequests.resolves([
         {
           headBranchName: `release-please--branches--release-1.3.x`,
@@ -111,17 +125,7 @@ describe('release', () => {
           sha: 'abc123',
           number: 42,
           title: defaultPRTitle,
-          body: new PullRequestBody(
-            [
-              {
-                version: defaultNextVersion,
-                notes: defaultPRNotes
-              }
-            ],
-            {
-              footer
-            }
-          ).toString(),
+          body,
           labels: [],
           files: []
         }
@@ -151,6 +155,25 @@ describe('release', () => {
 
       const release = await shouldRelease('main', prTitlePattern)
       expect(release).not.toBeDefined()
+    })
+
+    it('falls back to scanning the body when the footer is displaced by appended content', async () => {
+      const appended =
+        '\n\n---\n\n> [!NOTE]\n> **Low Risk**\n> Automated review note.\n'
+      setup(
+        defaultFooter,
+        {
+          'v1.3.1': {
+            name: 'v1.3.1',
+            sha: 'abs123'
+          } as GitHubTag
+        },
+        appended
+      )
+
+      const release = await shouldRelease('main', prTitlePattern)
+      expect(release).toBeDefined()
+      expect(release?.sha).toEqual('def456')
     })
 
     it('determines if the release is the latest version', async () => {

--- a/actions/should-release/src/release.ts
+++ b/actions/should-release/src/release.ts
@@ -64,6 +64,10 @@ type ReleaseMeta = {
 const footerPattern =
   /^Merging this PR will release the \[artifacts\]\(.*\) of (?<sha>\S+)$/
 
+// Fallback scan: another bot may append a `---` section after the footer, which PullRequestBody.parse then treats as the footer.
+const bodyFooterPattern =
+  /^Merging this PR will release the \[artifacts\]\(.*\) of (?<sha>\S+)$/m
+
 async function prepareSingleRelease(
   pullRequest: PullRequest,
   pullRequestTitlePattern: string,
@@ -99,8 +103,14 @@ async function prepareSingleRelease(
   }
 
   const footer = pullRequestBody.footer
-  const match = footer?.match(footerPattern)
+  let match = footer?.match(footerPattern)
   if (!match?.groups?.sha) {
+    match = pullRequest.body?.match(bodyFooterPattern)
+  }
+  if (!match?.groups?.sha) {
+    warning(
+      `Could not find release artifacts footer in PR #${pullRequest.number} body`
+    )
     return
   }
 


### PR DESCRIPTION
When the release PR body is modified, displacing the release artifacts from the footer (e.g., a cursor bot adding a comment to the PR description), the should-release step fails to find the footer required to identify the release artifacts, which in turn halts the release process.

In this PR, I am making artifacts lookup more robust by falling back to the body scan when the footer is not actually at the end of the PR body.