### PR TITLE
fix(CI): Remove spurious comma on failCheck

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -141,7 +141,7 @@
     - "name": "verify checks passed"
       "run": |
         echo "Some checks have failed!"
-        exit 1,
+        exit 1
   "faillint":
     "container":
       "image": "${{ inputs.build_image }}"

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -217,7 +217,7 @@ local validationJob = _validationJob();
                step.new('verify checks passed')
                + step.withRun(|||
                  echo "Some checks have failed!"
-                 exit 1,
+                 exit 1
                |||),
              ]),
 


### PR DESCRIPTION
This was giving extra errors in CI:

    line 2: exit: 1,: numeric argument required