### PR TITLE
ci: drop write permissions from Check PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-x64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,8 +40,8 @@ jobs:
   actions:
     runs-on: ubuntu-x64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,8 +77,8 @@ jobs:
   workflows:
     runs-on: ubuntu-x64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,8 +95,8 @@ jobs:
   test:
     runs-on: ubuntu-x64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     needs:
       - lint
       - actions
@@ -133,12 +133,12 @@ jobs:
   check-title:
     runs-on: ubuntu-x64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
-  contents: "write"
-  pull-requests: "write"
+  contents: "read"
+  pull-requests: "read"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,16 +9,16 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         env:
           cache-name: cache-node-modules
         with:
@@ -43,16 +43,16 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         env:
           cache-name: cache-node-modules
         with:
@@ -80,11 +80,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - uses: kobtea/setup-jsonnet-action@1ba74f3571a59047dd4c5b8cb365bd3656f88e2a # v1
@@ -102,16 +102,16 @@ jobs:
       - actions
       - workflows
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Summary

- Downgrade all permissions in `pr.yml` from `write` to `read` (both job-level and workflow-level)
- None of the 5 jobs (`lint`, `actions`, `workflows`, `test`, `check-title`) need write access
- This should unblock `pull_request`-triggered workflows that were silently disabled by the org-wide security policy after the coinbasecartel incident

## Context

Since ~May 16 the org tightened Actions permissions, blocking `pull_request`-triggered workflows requesting `write` permissions. This caused the "Check PR" workflow to stop firing entirely, leaving 3 required status checks (`check-title`, `test`, `create-release-pr`) in a permanent "expected" state and blocking PR merges (e.g. #325).

## Test plan

- [ ] Verify "Check PR" workflow triggers on this PR
- [ ] All 5 jobs pass: `lint`, `actions`, `workflows`, `test`, `check-title`