### PR TITLE
ci: disable npm/yarn install scripts to re-enable GitHub Actions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false


### PR DESCRIPTION
## Summary

- Add `.npmrc` with `ignore-scripts=true`
- Add `.yarnrc.yml` with `enableScripts: false`

GitHub Actions were disabled for `grafana/loki-release` as part of the [coinbasecartel incident response](https://raintank-corp.slack.com/archives/C0B30MXJCCV/p1778535501947719). Per [platform-productivity guidance](https://raintank-corp.slack.com/archives/C0B4D1WTSUU/p1779186992949589?thread_ts=1779098111.387199&cid=C0B4D1WTSUU), adding these files is required to re-enable workflow dispatch.

This prevents npm/yarn lifecycle scripts (preinstall, postinstall, etc.) from running automatically during `npm install` / `yarn install`, mitigating supply chain attacks via malicious package install hooks. Explicit `npm run <script>` commands in workflows are unaffected.

## Context

This is a prerequisite for re-enabling Actions on this repo. Once merged, platform-productivity (@dylan-wylie) can flip the switch. A follow-up PR (#326) hardens `pr.yml` further with read-only permissions and pinned action SHAs.

## Test plan

- [ ] Merge this PR and request Actions re-enablement from platform-productivity
- [ ] Verify `npm install` + `npm run lint` / `npm run ci-test` still pass (install scripts from dependencies are not needed)