### PR TITLE
ci: verify Test Create Release PR Action after yarn 4 migration

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -467,6 +467,7 @@ name: "Test Create Release PR Action"
   push:
     branches:
     - "release-[0-9]+.[0-9]+.x"
+  workflow_dispatch: {}
 permissions:
   contents: "read"
   pull-requests: "read"

--- a/workflows/workflows.jsonnet
+++ b/workflows/workflows.jsonnet
@@ -45,6 +45,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       name: 'Test Create Release PR Action',
       on+: {
         pull_request: {},
+        workflow_dispatch: {},
       },
     }, false, false
   ),


### PR DESCRIPTION
## What

- Adds `workflow_dispatch` trigger to `test-release-pr.yml` (via jsonnet) so the workflow can be re-run manually.
- Regenerates the YAML.

## Why

The 'version' job in **Test Create Release PR Action** failed on every commit of #329 because the job checks out main into `lib/` and runs `yarn install` from there. At the time, main's `package.json` had no `"packageManager"` field, so Corepack defaulted to **yarn 1.22.22** — which couldn't operate against #329's yarn 4 lockfile and couldn't find the `release-please` binary.

Now that #329 is merged, `lib/` checkout of main sees `packageManager: yarn@4.15.0` and Corepack provisions the correct version. **Opening this PR is itself the verification** — the workflow runs on `pull_request` and should now go green.

`workflow_dispatch` is added as future-proofing so this workflow can be re-triggered on demand without opening a throwaway PR.

## Verification

Local checks all green: `yarn run format:check`, `yarn run lint`, `yarn run ci-test` (24/24).

The real verification is the CI run on this PR itself — specifically the `version` job within **Test Create Release PR Action**, which is what was failing previously.