### PR TITLE
fix(release): Create dist/ before downloading release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
     - name: "download binaries"
       run: |
         echo "downloading binaries to $(pwd)/dist"
+        mkdir -p dist
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -100,6 +100,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    releaseStep('download binaries')
                    + step.withRun(|||
                      echo "downloading binaries to $(pwd)/dist"
+                     mkdir -p dist
                      gcloud artifacts generic download \
                        --project="grafanalabs-dev" \
                        --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \


### PR DESCRIPTION
The workflow fails after #347, see https://github.com/grafana/loki/actions/runs/27164012029/job/80186522242