### PR TITLE
fix(release): Download artifacts by release sha instead of trigger sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
           --location="us" \
           --package=binaries \
-          --version=${{ github.sha }} \
+          --version=$(echo ${SHA} | tr -d '"') \
           --destination=dist/
       working-directory: "release"
     - env:
@@ -241,7 +241,7 @@ jobs:
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
           --location="us" \
           --package=plugins \
-          --version=${{ github.sha }} \
+          --version=$(echo ${SHA} | tr -d '"') \
           --destination=plugins/
         mkdir -p "release/clients/cmd/docker-driver"
     - name: "publish docker driver"
@@ -284,7 +284,7 @@ jobs:
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
           --location="us" \
           --package=images \
-          --version=${{ github.sha }} \
+          --version=$(echo ${SHA} | tr -d '"') \
           --destination=images/
     - name: "publish docker images"
       uses: "./lib/actions/push-images"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -105,7 +105,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                        --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
                        --location="us" \
                        --package=binaries \
-                       --version=${{ github.sha }} \
+                       --version=$(echo ${SHA} | tr -d '"') \
                        --destination=dist/
                    |||),
 
@@ -208,7 +208,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
             --location="us" \
             --package=images \
-            --version=${{ github.sha }} \
+            --version=$(echo ${SHA} | tr -d '"') \
             --destination=images/
         |||),
         step.new('publish docker images', './lib/actions/push-images')
@@ -245,7 +245,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
             --location="us" \
             --package=plugins \
-            --version=${{ github.sha }} \
+            --version=$(echo ${SHA} | tr -d '"') \
             --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),


### PR DESCRIPTION
Follow up from https://github.com/grafana/loki-release/pull/370, complements https://github.com/grafana/loki-release/pull/347