### PR TITLE
chore: Remove promtail_journal_enabled build tag

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -228,7 +228,7 @@
       "name": "golangci-lint"
       "uses": "golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9"
       "with":
-        "args": "-v --timeout 15m --build-tags linux,promtail_journal_enabled"
+        "args": "-v --timeout 15m --build-tags linux"
         "only-new-issues": false
         "version": "${{ inputs.golang_ci_lint_version }}"
   "integration":

--- a/workflows/validate.libsonnet
+++ b/workflows/validate.libsonnet
@@ -175,7 +175,7 @@ local validationJob = _validationJob();
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': false,  // we want a PR to fail if the target branch fails
-          args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
+          args: '-v --timeout 15m --build-tags linux',
         }),
       ],
     )


### PR DESCRIPTION
Breaks CI on release-3.6.x due to not having the libsystemd headers or libraries.