### PR TITLE
fix(ci): Use new uppercase pattern for PR titles and release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,13 +95,20 @@ jobs:
       name: "create release"
       run: |
         yarn install
-        yarn exec -- release-please github-release \
+        output=$(yarn exec -- release-please github-release \
           --draft \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
-          --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')"
+          --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
+        echo "$output"
+        if [[ "$output" == "[]" || -z "$output" ]]; then
+          echo "::error::release-please did not create a release"
+          exit 1
+        fi
       working-directory: "lib"
     - env:
         GH_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -142,13 +142,20 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    })
                    + step.withRun(|||
                      yarn install
-                     yarn exec -- release-please github-release \
+                     output=$(yarn exec -- release-please github-release \
                        --draft \
                        --release-type simple \
                        --repo-url "${{ env.RELEASE_REPO }}" \
                        --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
                        --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
-                       --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')"
+                       --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')" \
+                       --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
+                       --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
+                     echo "$output"
+                     if [[ "$output" == "[]" || -z "$output" ]]; then
+                       echo "::error::release-please did not create a release"
+                       exit 1
+                     fi
                    |||),
 
                    releaseStep('upload artifacts')


### PR DESCRIPTION
The change to require capital letters for the PR title broke release-please.
([job](https://github.com/grafana/loki/actions/runs/28028545982/job/82962772410))
```
Bad pull request title: 'chore(release-3.7.x): Release 3.7.3'
```