### PR TITLE
fix(release): Fix github-release tagging of capitalized release PR titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')" \
-          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
-          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
         echo "$output"
         if [[ "$output" == "[]" || -z "$output" ]]; then
           echo "::error::release-please did not create a release"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@actions/tool-cache": "2.0.2",
     "chalk": "4.1.2",
     "figures": "3.2.0",
-    "release-please": "grafana/release-please#32b5b78a94632f4c2920e1beaca57abab2e16ead"
+    "release-please": "grafana/release-please#7d1d0e77d695d53317d2a01696836ce02449da46"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -149,8 +149,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                        --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
                        --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
                        --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')" \
-                       --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
-                       --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
+                       --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
                      echo "$output"
                      if [[ "$output" == "[]" || -z "$output" ]]; then
                        echo "::error::release-please did not create a release"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5303,7 +5303,7 @@ __metadata:
     make-coverage-badge: "npm:1.2.0"
     prettier: "npm:3.8.3"
     prettier-eslint: "npm:16.4.2"
-    release-please: "grafana/release-please#32b5b78a94632f4c2920e1beaca57abab2e16ead"
+    release-please: "grafana/release-please#7d1d0e77d695d53317d2a01696836ce02449da46"
     sinon: "npm:16.0.0"
     ts-jest: "npm:29.4.9"
     ts-node: "npm:10.9.2"
@@ -6210,9 +6210,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"release-please@grafana/release-please#32b5b78a94632f4c2920e1beaca57abab2e16ead":
+"release-please@grafana/release-please#7d1d0e77d695d53317d2a01696836ce02449da46":
   version: 16.9.0
-  resolution: "release-please@https://github.com/grafana/release-please.git#commit=32b5b78a94632f4c2920e1beaca57abab2e16ead"
+  resolution: "release-please@https://github.com/grafana/release-please.git#commit=7d1d0e77d695d53317d2a01696836ce02449da46"
   dependencies:
     "@conventional-commits/parser": "npm:^0.4.1"
     "@google-automations/git-file-utils": "npm:^2.0.0"
@@ -6247,7 +6247,7 @@ __metadata:
     yargs: "npm:^17.0.0"
   bin:
     release-please: ./build/src/bin/release-please.js
-  checksum: 10c0/e996fe15540c8c8b217fcf45d98dd5348c97b9f34c80e40115a636dc38b1758b965cce440bce07333b98e1fb94e9291e176fbb6e88a8ddce6a804dc00cca085b
+  checksum: 10c0/67f1dae191466cc240a210ba5ee175bcdc1c50bc7ce20d63d4d2916d6d3002711d5bb5db7a22d2a5362edfcae745b8fefcb181d63e85074f5de92c77b162cce1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Makes `github-release` able to tag our merged release PRs again, which unblocks the 3.6.12 / 3.7.3 patch releases.

Two commits:

1. **Bump release-please** to grafana/release-please#5 (`7d1d0e77`). `github-release` accepted `--pull-request-title-pattern` but never forwarded it to the release strategy (only `release-pr` did), so it fell back to the default lowercase pattern.
2. **Drop `--group-pull-request-title-pattern`** from the `github-release` step. release-please only defines that flag for `release-pr`; on `github-release` it errors out with `Unknown arguments`. We keep `--pull-request-title-pattern` (now effective) and keep the group flag on all `release-pr` invocations, where it's valid and needed for the grouped PR title.

## Why

Our release PR title is `chore(release-3.7.x): Release 3.7.3` (capital R, required by Loki's PR-title lint). `github-release` couldn't parse that, so the merged release PR never got tagged, and the next `patch-release-pr` run aborted with `There are untagged, merged release PRs outstanding`.

## Verification

`github-release --dry-run` at the bumped sha against the stuck branches:
- release-3.7.x → `Would tag 1 releases: v3.7.3`
- release-3.6.x → `Would tag 1 releases: v3.6.12`

(Before: `Bad pull request title` / `Would tag 0 releases`.)

Supersedes the earlier single-commit version of this PR.
