### PR TITLE
fix(release): Create images and plugins dirs before gcloud download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,7 @@ jobs:
       name: "download and prepare plugins"
       run: |
         echo "downloading plugins to $(pwd)/plugins"
+        mkdir -p plugins
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
@@ -286,6 +287,7 @@ jobs:
       name: "download images"
       run: |
         echo "downloading images to $(pwd)/images"
+        mkdir -p images
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -210,6 +210,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         })
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
+          mkdir -p images
           gcloud artifacts generic download \
             --project="grafanalabs-dev" \
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
@@ -247,6 +248,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         })
         + step.withRun(|||
           echo "downloading plugins to $(pwd)/plugins"
+          mkdir -p plugins
           gcloud artifacts generic download \
             --project="grafanalabs-dev" \
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \


### PR DESCRIPTION
The GAR migration (#347) swapped gsutil (which created the dir on copy) for `gcloud artifacts generic download --destination=images/`, which needs the dir to exist. It added `mkdir -p dist` for binaries but missed images and plugins, so both publish jobs fail with "Destination directory does not exist". This adds the two missing mkdirs.
