### PR TITLE
fix(release): Drop trailing comma in release artifacts upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           --project="grafanalabs-global" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-prod" \
           --location="us" \
-          --source-directory=${{ env.path }}, \
+          --source-directory=${{ env.path }} \
           --package=binaries \
           --version=${{ github.sha }}
       working-directory: "release"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -175,7 +175,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                        --project="grafanalabs-global" \
                        --repository="generic-${{ env.GAR_REPO_SLUG }}-prod" \
                        --location="us" \
-                       --source-directory=${{ env.path }}, \
+                       --source-directory=${{ env.path }} \
                        --package=binaries \
                        --version=${{ github.sha }}
                    |||)


### PR DESCRIPTION
The `publishToGCS`-gated `release artifacts` step passes `--source-directory=${{ env.path }},` with a trailing comma (introduced in #347), so `gcloud artifacts generic upload` fails with `Specified path is not an existing directory`.

Only consumers with `publishToGCS=true` run this step (GEL, not loki), which is why it surfaced only now when cutting a GEL 3.6 patch. Removes the comma and regenerates the workflows.