### PR TITLE
fix(release): Upload release artifacts from dist, not release/dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         gh release upload --clobber $(echo $OUTPUTS_NAME | tr -d '"') dist/*
       working-directory: "release"
     - env:
-        path: "release/dist"
+        path: "dist"
       if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
       name: "release artifacts"
       run: |

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -180,7 +180,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                        --version=${{ github.sha }}
                    |||)
                    + step.withEnv({
-                     path: 'release/dist',
+                     path: 'dist',
                    }),
                  ])
                  + job.withOutputs({


### PR DESCRIPTION
Follow-up to #380. The `release artifacts` step runs with `working-directory: release` but passed `--source-directory=release/dist`, so it looked for `release/release/dist` and failed with `Specified path is not an existing directory`.

The binaries live at `release/dist` (= `dist` relative to that cwd, same as the adjacent `gh release upload dist/*`). Changes the path env to `dist`. Only `publishToGCS=true` consumers (GEL) exercise this step, which is why both this and the comma (#380) were latent since #347.