### PR TITLE
fix(ci): Add support for publishing docker plugins to GAR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev"
+  PLUGIN_IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev"
   PUBLISH_TO_GCS: false
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki-release"
@@ -234,10 +235,10 @@ jobs:
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - name: "Login to DockerHub"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
     - name: "Login to GAR"
       uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      with:
+        registry: "us-docker.pkg.dev"
     - env:
         SHA: "${{ needs.createRelease.outputs.sha }}"
       name: "download and prepare plugins"
@@ -257,7 +258,7 @@ jobs:
       with:
         buildDir: "release/clients/cmd/docker-driver"
         imageDir: "plugins"
-        imagePrefix: "${{ env.IMAGE_PREFIX }}"
+        imagePrefix: "${{ env.PLUGIN_IMAGE_PREFIX }}"
         isLatest: "${{ needs.createRelease.outputs.isLatest }}"
         isPlugin: true
   publishImages:

--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -91,6 +91,7 @@
     branches=['release-[0-9].[0-9].x', 'k[0-9]*'],
     buildArtifactsBucket='loki-build-artifacts',
     imagePrefix='grafana',
+    pluginImagePrefix=null,
     pluginBuildDir='release/plugin-tmp-dir',
     publishBucket='',
     publishToGCS=false,
@@ -102,6 +103,7 @@
                   ) {
     local githubApp = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs-app' else 'loki-gh-app',
     local garRepoSlug = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs' else 'loki',
+    local effectivePluginImagePrefix = if pluginImagePrefix != null then pluginImagePrefix else imagePrefix,
 
     name: 'create release',
     on: {
@@ -119,6 +121,7 @@
     env: {
       BUILD_ARTIFACTS_BUCKET: buildArtifactsBucket,
       IMAGE_PREFIX: imagePrefix,
+      PLUGIN_IMAGE_PREFIX: effectivePluginImagePrefix,
       RELEASE_LIB_REF: releaseLibRef,
       RELEASE_REPO: releaseRepo,
       GAR_REPO_SLUG: garRepoSlug,

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -240,8 +240,8 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         common.fetchReleaseRepo,
         step.new('Set up QEMU', 'docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392'),  // v3
         step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
-        step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
-        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
+        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+        + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download and prepare plugins')
         + step.withEnv({
           SHA: '${{ needs.createRelease.outputs.sha }}',
@@ -261,7 +261,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
           imageDir: 'plugins',
-          imagePrefix: '${{ env.IMAGE_PREFIX }}',
+          imagePrefix: '${{ env.PLUGIN_IMAGE_PREFIX }}',
           isPlugin: true,
           buildDir: 'release/%s' % path,
           isLatest: '${{ needs.createRelease.outputs.isLatest }}',


### PR DESCRIPTION
Adds support for publishing Docker plugins via GAR (via GAR mirroring), as opposed to pushing to Dockerhub directly.

`workflows/main.jsonnet`:
- Added `pluginImagePrefix` parameter (defaults to `imagePrefix` when unset)
- Exposes `PLUGIN_IMAGE_PREFIX` in the release workflow env

`workflows/release.libsonnet`:
- Removed Docker Hub login from `publishDockerPlugins` (GAR-only, same as `images`)
- Plugin publish uses `PLUGIN_IMAGE_PREFIX` instead of `IMAGE_PREFIX`
- Added explicit registry: `us-docker.pkg.dev` on GAR login

Regenerated `.github/workflows/release.yml`