### PR TITLE
fix(ci): Authenticate docker plugin push to GAR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,12 @@ jobs:
           --version=$(echo ${SHA} | tr -d '"') \
           --destination=plugins/
         mkdir -p "release/clients/cmd/docker-driver"
+    - name: "Login to GAR for plugin push"
+      run: |
+        DOCKER_CONFIG="$(mktemp -d)"
+        echo "DOCKER_CONFIG=${DOCKER_CONFIG}" >> "${GITHUB_ENV}"
+        gcloud auth print-access-token \
+          | docker --config "${DOCKER_CONFIG}" login -u oauth2accesstoken --password-stdin us-docker.pkg.dev
     - name: "publish docker driver"
       uses: "./lib/actions/push-images"
       with:

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -258,6 +258,13 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),
+        step.new('Login to GAR for plugin push')
+        + step.withRun(|||
+          DOCKER_CONFIG="$(mktemp -d)"
+          echo "DOCKER_CONFIG=${DOCKER_CONFIG}" >> "${GITHUB_ENV}"
+          gcloud auth print-access-token \
+            | docker --config "${DOCKER_CONFIG}" login -u oauth2accesstoken --password-stdin us-docker.pkg.dev
+        |||),
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
           imageDir: 'plugins',


### PR DESCRIPTION
## What

Add a token-based `docker login` to the `publishDockerPlugins` job before the plugin is pushed, into an isolated `DOCKER_CONFIG`, and export that config to subsequent steps via `GITHUB_ENV`.

## Why

The 3.7.4 release [failed](https://github.com/grafana/loki/actions/runs/29895111499/job/88844123831) in `publishDockerPlugins` → *publish docker driver*:

```
docker plugin push "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror/loki-docker-driver:3.7.4-amd64"
→ error pushing plugin: failed to authorize: failed to fetch oauth token: ... 401 Unauthorized
```

`login-to-gar` authenticates docker by configuring the **gcloud credential helper** (`credHelpers["us-docker.pkg.dev"] = "gcloud"`). Regular `docker push` / buildx honour credential helpers — which is why the parallel `publishImages` job pushes to the same GAR repo fine. But **`docker plugin push` does not consult credential helpers**; it only reads static `auths` entries in the docker config. So the plugin push presents no credential and GAR returns 401.

This regressed in #382, which removed the DockerHub static login (`dockerhub-login`) from this job and repointed plugins at the GAR mirror. The old DockerHub login wrote a static `auths` entry that plugin push could use; the gcloud credHelper login does not.

## Fix

A plain `docker login us-docker.pkg.dev` against the default config wouldn't help — with a credHelper already configured for that host, `docker login` routes the credential to the helper's (no-op) store instead of writing `auths`. So we log in against a **fresh `DOCKER_CONFIG`** that has no credHelper; the login writes a real `auths` entry there, and exporting `DOCKER_CONFIG` makes the `publish docker driver` step (and its `docker plugin push`) use it.

## Rollout

The loki repo consumes this lib vendored + pinned. After merge, bump `.github/jsonnetfile.json` in grafana/loki (`release-3.7.x` and `main`) to this commit, regenerate `.github/workflows/release.yml`, and re-cut 3.7.4.