### PR TITLE
test(ci): Reproduce GAR docker plugin push auth failure [DO NOT MERGE]

### DIFF
--- a/.github/workflows/zz-repro-plugin-push.yml
+++ b/.github/workflows/zz-repro-plugin-push.yml
@@ -1,0 +1,70 @@
+name: "repro plugin push GAR auth"
+
+on:
+  push:
+    branches:
+      - "jnewbigin/repro-plugin-push-401"
+
+permissions:
+  contents: "read"
+  id-token: "write"
+
+jobs:
+  reproPluginPush:
+    runs-on: "ubuntu-x64"
+    env:
+      DEV_PREFIX: "us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev"
+    steps:
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      with:
+        registry: "us-docker.pkg.dev"
+    - name: "show docker + credential state"
+      run: |
+        docker version
+        echo "--- ~/.docker/config.json ---"
+        cat "${HOME}/.docker/config.json" || true
+        echo "--- docker-credential-gcloud present? ---"
+        command -v docker-credential-gcloud || echo "NOT on PATH"
+    - name: "build minimal plugin"
+      run: |
+        set -euxo pipefail
+        root="$(mktemp -d)"
+        mkdir -p "${root}/rootfs"
+        cat > "${root}/config.json" <<'JSON'
+        { "description": "repro", "entrypoint": ["/bin/true"],
+          "interface": { "types": ["docker.volumedriver/1.0"], "socket": "repro.sock" } }
+        JSON
+        echo "PLUGIN_ROOT=${root}" >> "${GITHUB_ENV}"
+    - name: "REPRO: plugin push with credential helper only (expect 401)"
+      id: "repro"
+      continue-on-error: true
+      run: |
+        set -euxo pipefail
+        ref="${DEV_PREFIX}/plugin-auth-repro:credhelper"
+        docker plugin create "${ref}" "${PLUGIN_ROOT}"
+        docker plugin push "${ref}"
+    - name: "report repro outcome"
+      env:
+        REPRO_OUTCOME: "${{ steps.repro.outcome }}"
+      run: |
+        echo "repro step outcome: ${REPRO_OUTCOME}"
+        if [ "${REPRO_OUTCOME}" = "failure" ]; then
+          echo "REPRODUCED: credential-helper-only 'docker plugin push' failed (matches the 3.7.4 release)."
+        else
+          echo "NOT reproduced: credential-helper-only 'docker plugin push' succeeded."
+        fi
+    - name: "FIX: plugin push via static auth in isolated DOCKER_CONFIG (expect success)"
+      run: |
+        set -euxo pipefail
+        ref="${DEV_PREFIX}/plugin-auth-repro:fixed"
+        DOCKER_CONFIG="$(mktemp -d)"
+        export DOCKER_CONFIG
+        gcloud auth print-access-token \
+          | docker login -u oauth2accesstoken --password-stdin us-docker.pkg.dev
+        docker plugin create "${ref}" "${PLUGIN_ROOT}"
+        docker plugin push "${ref}"

--- a/.github/workflows/zz-repro-plugin-push.yml
+++ b/.github/workflows/zz-repro-plugin-push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "jnewbigin/repro-plugin-push-401"
+  pull_request:
+    branches:
+      - "main"
 
 permissions:
   contents: "read"


### PR DESCRIPTION
Throwaway workflow to reproduce the `docker plugin push` 401 seen in the 3.7.4 release on the `ubuntu-x64` runner, and to prove the static-auth fix (PR #386) against the **dev** registry.

The `reproPluginPush` job:
1. `login-to-gar` (same as the real job) — configures the gcloud credential helper only.
2. Builds a minimal docker plugin.
3. **REPRO:** `docker plugin push` with the credential helper only → expected to 401 (`continue-on-error`).
4. **FIX:** `docker plugin push` after a static token `docker login` into an isolated `DOCKER_CONFIG` → expected to succeed.

**Do not merge** — delete once the fix is proven.