### PR TITLE
fix(ci): Publish docker plugin to GAR via crane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,14 +253,36 @@ jobs:
           --version=$(echo ${SHA} | tr -d '"') \
           --destination=plugins/
         mkdir -p "release/clients/cmd/docker-driver"
+    - name: "start local registry for plugins"
+      run: |
+        docker rm -f plugin-registry >/dev/null 2>&1 || true
+        docker run -d --name plugin-registry -p 5000:5000 registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+        for _ in $(seq 1 30); do
+          curl -sf http://localhost:5000/v2/ >/dev/null && break
+          sleep 1
+        done
     - name: "publish docker driver"
       uses: "./lib/actions/push-images"
       with:
         buildDir: "release/clients/cmd/docker-driver"
         imageDir: "plugins"
-        imagePrefix: "${{ env.PLUGIN_IMAGE_PREFIX }}"
+        imagePrefix: "localhost:5000"
         isLatest: "${{ needs.createRelease.outputs.isLatest }}"
         isPlugin: true
+    - name: "mirror plugins to GAR with crane"
+      run: |
+        set -euo pipefail
+        crane_version="v0.21.6"
+        curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+          | tar -xz crane
+        for repo in $(./crane catalog localhost:5000 --insecure); do
+          for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
+            layout="$(mktemp -d)"
+            echo "mirroring ${repo}:${tag} to ${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+            ./crane pull --insecure --format=oci "localhost:5000/${repo}:${tag}" "${layout}"
+            ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+          done
+        done
   publishImages:
     needs:
     - "createRelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,12 +255,16 @@ jobs:
         mkdir -p "release/clients/cmd/docker-driver"
     - name: "start local registry for plugins"
       run: |
-        docker rm -f plugin-registry >/dev/null 2>&1 || true
-        docker run -d --name plugin-registry -p 5000:5000 registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+        set -euo pipefail
+        crane_version="v0.21.6"
+        curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+          | tar -xz crane
+        nohup ./crane registry serve --address localhost:5000 >crane-registry.log 2>&1 &
         for _ in $(seq 1 30); do
           curl -sf http://localhost:5000/v2/ >/dev/null && break
           sleep 1
         done
+        curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
     - name: "publish docker driver"
       uses: "./lib/actions/push-images"
       with:
@@ -272,9 +276,6 @@ jobs:
     - name: "mirror plugins to GAR with crane"
       run: |
         set -euo pipefail
-        crane_version="v0.21.6"
-        curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
-          | tar -xz crane
         for repo in $(./crane catalog localhost:5000 --insecure); do
           for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
             layout="$(mktemp -d)"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -258,14 +258,38 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),
+        step.new('start local registry for plugins')
+        + step.withRun(|||
+          docker rm -f plugin-registry >/dev/null 2>&1 || true
+          docker run -d --name plugin-registry -p 5000:5000 registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+          for _ in $(seq 1 30); do
+            curl -sf http://localhost:5000/v2/ >/dev/null && break
+            sleep 1
+          done
+        |||),
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
           imageDir: 'plugins',
-          imagePrefix: '${{ env.PLUGIN_IMAGE_PREFIX }}',
+          imagePrefix: 'localhost:5000',
           isPlugin: true,
           buildDir: 'release/%s' % path,
           isLatest: '${{ needs.createRelease.outputs.isLatest }}',
         }),
+        step.new('mirror plugins to GAR with crane')
+        + step.withRun(|||
+          set -euo pipefail
+          crane_version="v0.21.6"
+          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz crane
+          for repo in $(./crane catalog localhost:5000 --insecure); do
+            for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
+              layout="$(mktemp -d)"
+              echo "mirroring ${repo}:${tag} to ${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+              ./crane pull --insecure --format=oci "localhost:5000/${repo}:${tag}" "${layout}"
+              ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+            done
+          done
+        |||),
       ]
     ),
 

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -261,13 +261,15 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         step.new('start local registry for plugins')
         + step.withRun(|||
           set -euo pipefail
-          docker rm -f plugin-registry >/dev/null 2>&1 || true
-          docker run -d --name plugin-registry -p 5000:5000 registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+          crane_version="v0.21.6"
+          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz crane
+          nohup ./crane registry serve --address localhost:5000 >crane-registry.log 2>&1 &
           for _ in $(seq 1 30); do
             curl -sf http://localhost:5000/v2/ >/dev/null && break
             sleep 1
           done
-          curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; docker logs plugin-registry || true; exit 1; }
+          curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
         |||),
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
@@ -280,9 +282,6 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         step.new('mirror plugins to GAR with crane')
         + step.withRun(|||
           set -euo pipefail
-          crane_version="v0.21.6"
-          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
-            | tar -xz crane
           for repo in $(./crane catalog localhost:5000 --insecure); do
             for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
               layout="$(mktemp -d)"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -260,12 +260,14 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         ||| % path),
         step.new('start local registry for plugins')
         + step.withRun(|||
+          set -euo pipefail
           docker rm -f plugin-registry >/dev/null 2>&1 || true
           docker run -d --name plugin-registry -p 5000:5000 registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
           for _ in $(seq 1 30); do
             curl -sf http://localhost:5000/v2/ >/dev/null && break
             sleep 1
           done
+          curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; docker logs plugin-registry || true; exit 1; }
         |||),
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({


### PR DESCRIPTION
## What
Change `publishDockerPlugins` to publish the loki-docker-driver plugin to GAR via `crane:
- start a temporary local registry served by crane itself (`crane registry serve`);
- point the existing `push-images` action at `localhost:5000`, so it `docker plugin create`s + `push`es into the local registry (which serves the plugin token scope);
- mirror each plugin into GAR with `crane` (`crane pull --format=oci` from localhost, `crane push` to `$PLUGIN_IMAGE_PREFIX`).

## Why
`docker plugin push` requests the `repository(plugin)` OCI token scope, which Google Artifact Registry does not support so publishing the driver to the GAR mirror fails, even though normal image pushes to the same repo succeed. This regressed when #382 repointed the driver at the GAR mirror.

The workaround is to use the google `crane` tool.

`crane cp` (and `crane push`) need an OCI-readable source: a registry, an OCI layout, or a tarball. A docker managed plugin is none of those. After `docker plugin create` it lives in the daemon's plugin store (`/var/lib/docker/plugins/…`) in docker's internal format. There is no `docker plugin save`, no `docker save` for plugins, and no way to point crane at the plugin store. The only way docker emits the plugin as an OCI artifact is docker plugin push which can only target a registry.

This means we need a local registry to push to before we can copy to GAR using `crane`.

## Downstream
The existing gar-image-mirror already copies GAR→`docker.io/grafana/loki-docker-driver` with `crane.Copy` (media types preserved; `loki-docker-driver` is allowlisted), so `docker plugin install grafana/loki-docker-driver` keeps working. GAR is only the mirror staging repo — `docker plugin install` can't pull from GAR directly regardless.

## Notes
- `crane` is downloaded version-pinned (matching the existing pattern for helm/buf/etc. in this pipeline) and also serves the temporary local registry, so the only new dependency is `crane` — no `registry:2` image.
- Supersedes #386 (credential-based approach, disproven — GAR rejects the plugin scope regardless of auth).
- Rollout: grafana/loki consumes this lib vendored + pinned, so after merge, bump `.github/jsonnetfile.json` + regenerate `release.yml` on `release-3.7.x` and `main`.