### PR TITLE
fix: Install nfpm in dist dependencies

### DIFF
--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -35,7 +35,7 @@ install_dist_dependencies() {
     GO111MODULE=on go install github.com/mitchellh/gox@9f71238
     apt-get install -qy zip
 
-    # Install nfpm for building .deb/.rpm packages (matches loki-build-image)
+    # Install nfpm for building .deb/.rpm packages
     GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.45.2
 }
 

--- a/workflows/install_workflow_dependencies.sh
+++ b/workflows/install_workflow_dependencies.sh
@@ -34,6 +34,9 @@ install_dist_dependencies() {
     # Install gox and zip for loki `dist` target
     GO111MODULE=on go install github.com/mitchellh/gox@9f71238
     apt-get install -qy zip
+
+    # Install nfpm for building .deb/.rpm packages (matches loki-build-image)
+    GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.45.2
 }
 
 install_lint_dependencies() {


### PR DESCRIPTION
## What

Add `nfpm@v2.45.2` to `install_dist_dependencies()` in `workflows/install_workflow_dependencies.sh`.

## Why

When a release builds on a plain `golang` container (rather than `loki-build-image`), this script provisions the toolchain before `make dist packages`. `make packages` runs `tools/packaging/nfpm.sh`, which invokes `nfpm` to build the `.deb`/`.rpm` packages — but `install_dist_dependencies` never installed `nfpm` (it only installed the older `fpm` toolchain). Because `nfpm.sh` has no `set -e`, the missing binary failed silently, so Loki releases from `v3.6.12` / `v3.7.3` (2026-06-24) onward shipped **without any `.deb`/`.rpm` assets**. That in turn left `apt.grafana.com` / `rpm.grafana.com` stalled at `v3.7.2`.

`nfpm@v2.45.2` matches the version `grafana/loki`'s `loki-build-image` bundles, keeping both build paths (fat image vs golang image) in parity.

Downstream tracking issue: grafana/loki#23585 (user-reported symptom: grafana/loki#23341).

## Testing

Ran the exact release step (`install_workflow_dependencies.sh dist` → `make dist packages`) against `grafana/loki` `release-3.7.x` in a `golang:1.26.5` container: **all 18 packages produced** (`loki`, `loki-canary`, `logcli` × `{amd64, arm64, arm}` × `{deb, rpm}`). The baseline without this change produced none.

## Notes / out of scope

- `fpm`/`ruby`/`rpm` are intentionally **kept** — GEL's `make packages` still shells out to `fpm`.
- Latent: `nfpm@v2.45.2` requires Go 1.25, while the library default `buildImage` is `golang:1.24`. Not a problem for current consumers (Loki builds on `golang:1.26.5`; GEL uses `fpm`), but a future nfpm consumer on the `1.24` default would need a newer Go.
- Consider centralizing an `NFPM_VERSION` so this pin can't silently drift from `loki-build-image`.