### PR TITLE
test(ci): Publish to the dev registry on PRs

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -7,7 +7,8 @@ env:
   DRY_RUN: true
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
-  IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev"
+  IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}"
+  PLUGIN_IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}"
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki-release"
   SKIP_VALIDATION: false
@@ -336,6 +337,122 @@ jobs:
         - arch: "linux/arm64"
           runs_on:
           - "ubuntu-arm64"
+  publishDockerPlugins:
+    needs:
+    - "loki"
+    - "loki-docker-driver"
+    permissions:
+      id-token: "write"
+    runs-on: "ubuntu-x64"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        persist-credentials: false
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        persist-credentials: false
+        repository: "${{ env.RELEASE_REPO }}"
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      with:
+        registry: "us-docker.pkg.dev"
+    - env:
+        SHA: "${{ github.sha }}"
+      name: "download and prepare plugins"
+      run: |
+        echo "downloading plugins to $(pwd)/plugins"
+        mkdir -p plugins
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --package=plugins \
+          --version=$(echo ${SHA} | tr -d '"') \
+          --destination=plugins/
+        mkdir -p "release/clients/cmd/docker-driver"
+    - name: "start local registry for plugins"
+      run: |
+        set -euo pipefail
+        crane_version="v0.21.6"
+        curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+          | tar -xz crane
+        nohup ./crane registry serve --address localhost:5000 >crane-registry.log 2>&1 &
+        for _ in $(seq 1 30); do
+          curl -sf http://localhost:5000/v2/ >/dev/null && break
+          sleep 1
+        done
+        curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
+    - name: "publish docker driver"
+      uses: "./lib/actions/push-images"
+      with:
+        buildDir: "release/clients/cmd/docker-driver"
+        imageDir: "plugins"
+        imagePrefix: "localhost:5000"
+        isLatest: "false"
+        isPlugin: true
+    - name: "mirror plugins to GAR with crane"
+      run: |
+        set -euo pipefail
+        for repo in $(./crane catalog localhost:5000 --insecure); do
+          for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
+            layout="$(mktemp -d)"
+            echo "mirroring ${repo}:${tag} to ${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+            ./crane pull --insecure --format=oci "localhost:5000/${repo}:${tag}" "${layout}"
+            ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+          done
+        done
+  publishImages:
+    needs:
+    - "loki"
+    - "loki-docker-driver"
+    permissions:
+      id-token: "write"
+    runs-on: "ubuntu-x64"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        persist-credentials: false
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      with:
+        registry: "us-docker.pkg.dev"
+    - env:
+        SHA: "${{ github.sha }}"
+      name: "download images"
+      run: |
+        echo "downloading images to $(pwd)/images"
+        mkdir -p images
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --package=images \
+          --version=$(echo ${SHA} | tr -d '"') \
+          --destination=images/
+    - name: "publish docker images"
+      uses: "./lib/actions/push-images"
+      with:
+        imageDir: "images"
+        imagePrefix: "${{ env.IMAGE_PREFIX }}"
+        isLatest: "false"
   version:
     needs:
     - "check"

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -191,9 +191,9 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    exists: '${{ steps.check_release.outputs.exists }}',
                  }),
 
-  publishImages: function()
+  publishImages: function(needs=['createRelease'], sha='${{ needs.createRelease.outputs.sha }}', isLatest='${{ needs.createRelease.outputs.isLatest }}')
     job.new()
-    + job.withNeeds(['createRelease'])
+    + job.withNeeds(needs)
     + job.withPermissions({
       'id-token': 'write',
     })
@@ -206,7 +206,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download images')
         + step.withEnv({
-          SHA: '${{ needs.createRelease.outputs.sha }}',
+          SHA: sha,
         })
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
@@ -223,14 +223,14 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({
           imageDir: 'images',
           imagePrefix: '${{ env.IMAGE_PREFIX }}',
-          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
+          isLatest: isLatest,
         }),
       ]
     ),
 
-  publishDockerPlugins: function(path)
+  publishDockerPlugins: function(path, needs=['createRelease'], sha='${{ needs.createRelease.outputs.sha }}', isLatest='${{ needs.createRelease.outputs.isLatest }}')
     job.new()
-    + job.withNeeds(['createRelease'])
+    + job.withNeeds(needs)
     + job.withPermissions({
       'id-token': 'write',
     })
@@ -244,7 +244,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download and prepare plugins')
         + step.withEnv({
-          SHA: '${{ needs.createRelease.outputs.sha }}',
+          SHA: sha,
         })
         + step.withRun(|||
           echo "downloading plugins to $(pwd)/plugins"
@@ -277,7 +277,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
           imagePrefix: 'localhost:5000',
           isPlugin: true,
           buildDir: 'release/%s' % path,
-          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
+          isLatest: isLatest,
         }),
         step.new('mirror plugins to GAR with crane')
         + step.withRun(|||

--- a/workflows/workflows.jsonnet
+++ b/workflows/workflows.jsonnet
@@ -46,6 +46,23 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       on+: {
         pull_request: {},
       },
+      env+: {
+        IMAGE_PREFIX: 'us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}',
+        PLUGIN_IMAGE_PREFIX: 'us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}',
+      },
+      jobs+: {
+        publishImages: lokiRelease.release.publishImages(
+          needs=['loki', 'loki-docker-driver'],
+          sha='${{ github.sha }}',
+          isLatest='false',
+        ),
+        publishDockerPlugins: lokiRelease.release.publishDockerPlugins(
+          dockerPluginDir,
+          needs=['loki', 'loki-docker-driver'],
+          sha='${{ github.sha }}',
+          isLatest='false',
+        ),
+      },
     }, false, false
   ),
   '.github/workflows/release.yml': std.manifestYamlDoc(


### PR DESCRIPTION
## What
Add `publishImages` and `publishDockerPlugins` jobs to `test-release-pr.yml` so every PR runs the real publish path against the **dev** registry (`docker-loki-dev`), under a per-run path `…/ci/${{ github.run_id }}/`.

## Why
The release tooling builds images and plugins in PR CI but only ran its publish path during a production release, so publish-time failures — e.g. GAR rejecting the docker plugin `repository(plugin)` token scope (fixed in #389) — were caught only at release time. This gives the publish path pre-release coverage.

## How
- **`release.libsonnet`** — `publishImages`/`publishDockerPlugins` are parameterized on `needs`/`sha`/`isLatest`, defaulting to the prior hardcoded values, so production `release.yml`/`release-pr.yml` regenerate **byte-identical** (verified).
- **`workflows.jsonnet`** (test-release-pr only) — reuse those **same** job functions with `needs=[loki, loki-docker-driver]`, `sha=${{ github.sha }}` (the artifacts the build jobs already upload for this run), `isLatest=false`, and dev prefixes carrying `/ci/${{ github.run_id }}` for per-run uniqueness.

Reusing the exact production job definitions means the test can't drift from what actually ships.

## Notes
- **Depends on #389** (crane-based plugin publish) — already on `main`; without it the dev plugin publish would 401 the same way.
- Publishes to dev on **every PR**; per-run paths accumulate (the CI identity has `writer` but not `delete` on `docker-loki-dev`). A **retention policy is a follow-up**.
- **Self-validating:** `test-release-pr.yml` runs on `pull_request`, so opening this PR executes the new `publishImages`/`publishDockerPlugins` jobs against dev.