### PR TITLE
test(ci): Publish smoke-test images in parallel with the builds

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -337,10 +337,7 @@ jobs:
         - arch: "linux/arm64"
           runs_on:
           - "ubuntu-arm64"
-  publishDockerPlugins:
-    needs:
-    - "loki"
-    - "loki-docker-driver"
+  publishTestDockerPlugin:
     permissions:
       id-token: "write"
     runs-on: "ubuntu-x64"
@@ -358,28 +355,24 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - name: "Login to GAR"
       uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
       with:
         registry: "us-docker.pkg.dev"
-    - env:
-        SHA: "${{ github.sha }}"
-      name: "download and prepare plugins"
+    - name: "build test plugin rootfs"
       run: |
-        echo "downloading plugins to $(pwd)/plugins"
-        mkdir -p plugins
-        gcloud artifacts generic download \
-          --project="grafanalabs-dev" \
-          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
-          --location="us" \
-          --package=plugins \
-          --version=$(echo ${SHA} | tr -d '"') \
-          --destination=plugins/
-        mkdir -p "release/clients/cmd/docker-driver"
+        set -euo pipefail
+        mkdir -p test-plugins
+        echo "loki-release publish smoke test" >testfile
+        printf 'FROM scratch\nCOPY testfile /testfile\n' >Dockerfile.test
+        docker buildx build \
+          --platform linux/amd64 \
+          --file Dockerfile.test \
+          --output "type=local,dest=test-plugin-rootfs" \
+          .
+        tar -cf "test-plugins/test-plugin-0.0.1-linux-amd64.tar" -C test-plugin-rootfs .
     - name: "start local registry for plugins"
       run: |
         set -euo pipefail
@@ -392,11 +385,11 @@ jobs:
           sleep 1
         done
         curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
-    - name: "publish docker driver"
+    - name: "publish test plugin"
       uses: "./lib/actions/push-images"
       with:
         buildDir: "release/clients/cmd/docker-driver"
-        imageDir: "plugins"
+        imageDir: "test-plugins"
         imagePrefix: "localhost:5000"
         isLatest: "false"
         isPlugin: true
@@ -411,10 +404,7 @@ jobs:
             ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
           done
         done
-  publishImages:
-    needs:
-    - "loki"
-    - "loki-docker-driver"
+  publishTestImage:
     permissions:
       id-token: "write"
     runs-on: "ubuntu-x64"
@@ -426,31 +416,28 @@ jobs:
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - name: "Login to GAR"
       uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
       with:
         registry: "us-docker.pkg.dev"
-    - env:
-        SHA: "${{ github.sha }}"
-      name: "download images"
+    - name: "build test image"
       run: |
-        echo "downloading images to $(pwd)/images"
-        mkdir -p images
-        gcloud artifacts generic download \
-          --project="grafanalabs-dev" \
-          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
-          --location="us" \
-          --package=images \
-          --version=$(echo ${SHA} | tr -d '"') \
-          --destination=images/
-    - name: "publish docker images"
+        set -euo pipefail
+        mkdir -p test-images
+        echo "loki-release publish smoke test" >testfile
+        printf 'FROM scratch\nCOPY testfile /testfile\n' >Dockerfile.test
+        docker buildx build \
+          --platform linux/amd64 \
+          --file Dockerfile.test \
+          --tag "${IMAGE_PREFIX}/test-image:0.0.1-amd64" \
+          --output "type=docker,dest=test-images/test-image-0.0.1-linux-amd64.tar" \
+          .
+    - name: "publish test image"
       uses: "./lib/actions/push-images"
       with:
-        imageDir: "images"
+        imageDir: "test-images"
         imagePrefix: "${{ env.IMAGE_PREFIX }}"
         isLatest: "false"
   version:

--- a/workflows/common.libsonnet
+++ b/workflows/common.libsonnet
@@ -104,6 +104,35 @@
       'persist-credentials': false,
     }),
 
+  startLocalPluginRegistry:
+    $.step.new('start local registry for plugins')
+    + $.step.withRun(|||
+      set -euo pipefail
+      crane_version="v0.21.6"
+      curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+        | tar -xz crane
+      nohup ./crane registry serve --address localhost:5000 >crane-registry.log 2>&1 &
+      for _ in $(seq 1 30); do
+        curl -sf http://localhost:5000/v2/ >/dev/null && break
+        sleep 1
+      done
+      curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
+    |||),
+
+  mirrorPluginsToGar:
+    $.step.new('mirror plugins to GAR with crane')
+    + $.step.withRun(|||
+      set -euo pipefail
+      for repo in $(./crane catalog localhost:5000 --insecure); do
+        for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
+          layout="$(mktemp -d)"
+          echo "mirroring ${repo}:${tag} to ${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+          ./crane pull --insecure --format=oci "localhost:5000/${repo}:${tag}" "${layout}"
+          ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+        done
+      done
+    |||),
+
   setupNode: $.step.new('setup node', 'actions/setup-node@v4')
              + $.step.with({
                'node-version': 24,

--- a/workflows/main.jsonnet
+++ b/workflows/main.jsonnet
@@ -4,6 +4,7 @@
   step: $.common.step,
   build: import 'build.libsonnet',
   release: import 'release.libsonnet',
+  testPublish: import 'test-publish.libsonnet',
   validate: import 'validate.libsonnet',
   validateGel: import 'validate-gel.libsonnet',
 

--- a/workflows/release.libsonnet
+++ b/workflows/release.libsonnet
@@ -191,9 +191,9 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    exists: '${{ steps.check_release.outputs.exists }}',
                  }),
 
-  publishImages: function(needs=['createRelease'], sha='${{ needs.createRelease.outputs.sha }}', isLatest='${{ needs.createRelease.outputs.isLatest }}')
+  publishImages: function()
     job.new()
-    + job.withNeeds(needs)
+    + job.withNeeds(['createRelease'])
     + job.withPermissions({
       'id-token': 'write',
     })
@@ -206,7 +206,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download images')
         + step.withEnv({
-          SHA: sha,
+          SHA: '${{ needs.createRelease.outputs.sha }}',
         })
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
@@ -223,14 +223,14 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({
           imageDir: 'images',
           imagePrefix: '${{ env.IMAGE_PREFIX }}',
-          isLatest: isLatest,
+          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
         }),
       ]
     ),
 
-  publishDockerPlugins: function(path, needs=['createRelease'], sha='${{ needs.createRelease.outputs.sha }}', isLatest='${{ needs.createRelease.outputs.isLatest }}')
+  publishDockerPlugins: function(path)
     job.new()
-    + job.withNeeds(needs)
+    + job.withNeeds(['createRelease'])
     + job.withPermissions({
       'id-token': 'write',
     })
@@ -244,7 +244,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download and prepare plugins')
         + step.withEnv({
-          SHA: sha,
+          SHA: '${{ needs.createRelease.outputs.sha }}',
         })
         + step.withRun(|||
           echo "downloading plugins to $(pwd)/plugins"
@@ -258,39 +258,16 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),
-        step.new('start local registry for plugins')
-        + step.withRun(|||
-          set -euo pipefail
-          crane_version="v0.21.6"
-          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
-            | tar -xz crane
-          nohup ./crane registry serve --address localhost:5000 >crane-registry.log 2>&1 &
-          for _ in $(seq 1 30); do
-            curl -sf http://localhost:5000/v2/ >/dev/null && break
-            sleep 1
-          done
-          curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
-        |||),
+        common.startLocalPluginRegistry,
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
           imageDir: 'plugins',
           imagePrefix: 'localhost:5000',
           isPlugin: true,
           buildDir: 'release/%s' % path,
-          isLatest: isLatest,
+          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
         }),
-        step.new('mirror plugins to GAR with crane')
-        + step.withRun(|||
-          set -euo pipefail
-          for repo in $(./crane catalog localhost:5000 --insecure); do
-            for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
-              layout="$(mktemp -d)"
-              echo "mirroring ${repo}:${tag} to ${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
-              ./crane pull --insecure --format=oci "localhost:5000/${repo}:${tag}" "${layout}"
-              ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
-            done
-          done
-        |||),
+        common.mirrorPluginsToGar,
       ]
     ),
 

--- a/workflows/test-publish.libsonnet
+++ b/workflows/test-publish.libsonnet
@@ -1,0 +1,78 @@
+local common = import 'common.libsonnet';
+local job = common.job;
+local step = common.step;
+
+// These jobs smoke test the publish path on pull requests. They build their own
+// throwaway fixtures instead of consuming the artifacts produced by the image
+// build jobs, so they carry no `needs` and run alongside the rest of the
+// workflow rather than at the end of it.
+local fixtureVersion = '0.0.1';
+
+{
+  publishTestImage:
+    job.new()
+    + job.withPermissions({
+      'id-token': 'write',
+    })
+    + job.withSteps([
+      common.fetchReleaseLib,
+      step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+      + step.with({ registry: 'us-docker.pkg.dev' }),
+      step.new('build test image')
+      + step.withRun(|||
+        set -euo pipefail
+        mkdir -p test-images
+        echo "loki-release publish smoke test" >testfile
+        printf 'FROM scratch\nCOPY testfile /testfile\n' >Dockerfile.test
+        docker buildx build \
+          --platform linux/amd64 \
+          --file Dockerfile.test \
+          --tag "${IMAGE_PREFIX}/test-image:%(version)s-amd64" \
+          --output "type=docker,dest=test-images/test-image-%(version)s-linux-amd64.tar" \
+          .
+      ||| % { version: fixtureVersion }),
+      step.new('publish test image', './lib/actions/push-images')
+      + step.with({
+        imageDir: 'test-images',
+        imagePrefix: '${{ env.IMAGE_PREFIX }}',
+        isLatest: 'false',
+      }),
+    ]),
+
+  publishTestDockerPlugin: function(path)
+    job.new()
+    + job.withPermissions({
+      'id-token': 'write',
+    })
+    + job.withSteps([
+      common.fetchReleaseLib,
+      common.fetchReleaseRepo,
+      step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+      + step.with({ registry: 'us-docker.pkg.dev' }),
+      step.new('build test plugin rootfs')
+      + step.withRun(|||
+        set -euo pipefail
+        mkdir -p test-plugins
+        echo "loki-release publish smoke test" >testfile
+        printf 'FROM scratch\nCOPY testfile /testfile\n' >Dockerfile.test
+        docker buildx build \
+          --platform linux/amd64 \
+          --file Dockerfile.test \
+          --output "type=local,dest=test-plugin-rootfs" \
+          .
+        tar -cf "test-plugins/test-plugin-%(version)s-linux-amd64.tar" -C test-plugin-rootfs .
+      ||| % { version: fixtureVersion }),
+      common.startLocalPluginRegistry,
+      step.new('publish test plugin', './lib/actions/push-images')
+      + step.with({
+        imageDir: 'test-plugins',
+        imagePrefix: 'localhost:5000',
+        isPlugin: true,
+        buildDir: 'release/%s' % path,
+        isLatest: 'false',
+      }),
+      common.mirrorPluginsToGar,
+    ]),
+}

--- a/workflows/workflows.jsonnet
+++ b/workflows/workflows.jsonnet
@@ -51,17 +51,8 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
         PLUGIN_IMAGE_PREFIX: 'us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}',
       },
       jobs+: {
-        publishImages: lokiRelease.release.publishImages(
-          needs=['loki', 'loki-docker-driver'],
-          sha='${{ github.sha }}',
-          isLatest='false',
-        ),
-        publishDockerPlugins: lokiRelease.release.publishDockerPlugins(
-          dockerPluginDir,
-          needs=['loki', 'loki-docker-driver'],
-          sha='${{ github.sha }}',
-          isLatest='false',
-        ),
+        publishTestImage: lokiRelease.testPublish.publishTestImage,
+        publishTestDockerPlugin: lokiRelease.testPublish.publishTestDockerPlugin(dockerPluginDir),
       },
     }, false, false
   ),


### PR DESCRIPTION
> **Draft — parked.** The mechanism works exactly as intended, but 37s isn't worth the coverage it costs, so this isn't worth merging on its own. It stays open because profiling the run in order to measure it turned up somewhere far better to spend the effort — see [Where the run's time actually goes](#where-the-runs-time-actually-goes). Happy to close this and go straight at the `check` gate instead.

This PR replaces the pull-request-only `publishImages` and `publishDockerPlugins` jobs with `publishTestImage` and `publishTestDockerPlugin`, which build their own throwaway fixtures instead of consuming the artifacts from the `loki` and `loki-docker-driver` builds. Because they no longer need anything, they kick off at the same time as `check` rather than waiting at the back of the queue.

It's a speed experiment first and foremost. If the saving is worth having we can keep going and add a proper full test run on merge; if not, reverting is a one-liner in `workflows.jsonnet`.

## What the fixtures do

- **`publishTestImage`** — builds a `FROM scratch` image with a single file in it, exports it as `test-image-0.0.1-linux-amd64.tar`, and hands it to `push-images`. Exercises `docker load` → `docker push -a` → `docker manifest create`/`push` against the dev registry.
- **`publishTestDockerPlugin`** — builds the same scratch image as a `type=local` rootfs, tars it as `test-plugin-0.0.1-linux-amd64.tar`, then runs the real dance: `push-images --isPlugin` (so `docker plugin create` against the repo's actual `clients/cmd/docker-driver/config.json`) → local crane registry → crane mirror to GAR.

The two crane steps are now shared fields in `common.libsonnet`, so the smoke test runs literally the same shell as the production `publishDockerPlugins` job and the two can't drift apart. `publishImages`/`publishDockerPlugins` also go back to their parameterless signatures, since the `needs`/`sha`/`isLatest` arguments added in #392 no longer have any callers — `release.yml` and `release-pr.yml` regenerate byte-identical, which confirms that bit is behaviour-neutral.

## Measured saving: about 37 seconds, not the 1.5 minutes first estimated

The mechanism works exactly as intended — on run [30604482049](https://github.com/grafana/loki-release/actions/runs/30604482049) both fixture jobs started 1–2 seconds into the run and finished in ~48s, instead of starting ~8 minutes in. But the net saving is much smaller than first claimed, because `create-release-pr` *also* waits on every image build and takes about as long as the publish jobs did. It, not the publish jobs, sets the tail.

On the one directly comparable baseline, run [30422820304](https://github.com/grafana/loki-release/actions/runs/30422820304):

| tail job | start | finish |
| --- | --- | --- |
| `create-release-pr` | 04:46:31 | 04:47:23 |
| `publishImages` | 04:46:31 | 04:47:51 |
| `publishDockerPlugins` | 04:46:31 | **04:48:00** ← set the run's end |

Total was 9m34s. Take the publish jobs off the tail and the run ends with `create-release-pr` at 04:47:23, i.e. 8m57s. **Saving ≈ 37s.**

The run on this branch clocked 11m45s, but that isn't comparable: the `ubuntu-arm64` runners queued for close to three minutes (`loki (linux/arm)` sat waiting from 04:38:47 to 04:41:40), which the baseline didn't hit.

## Where the run's time actually goes

Since the point was to measure, here's the profile of run 30604482049 job by job and step by step — all 21 jobs and 309 steps. The critical path is one serial chain, and publishing was never the expensive link in it:

| stage | window | duration |
| --- | --- | --- |
| `check` gate | 0:01 → 3:56 | **3m55s** |
| `version` | 3:57 → 4:49 | 52s |
| image & dist builds | 4:51 → 7:53 | **3m02s** |
| `create-release-pr` | 7:55 → 8:47 | 52s |

Build windows come from the baseline's durations, since this branch's run reads 11m45s only because the three `ubuntu-arm64` builds sat in a runner queue for ~2m53s that the baseline didn't hit.

Three findings, ranked by what they'd actually buy.

### 1. The `check` gate is a pure gate — worth about four minutes

Nothing in the workflow reads `check`'s outputs; grepping for `needs.check` comes up empty. The dependency is policy, not data, and it currently sits right at the front, where lint blocks `version`, which blocks the builds, which block everything else.

Moving the gate to the one job that has an outward-facing effect is two lines in `releasePRWorkflow`:

```jsonnet
version: $.build.version,                     // was: + withNeeds(['check'])
'create-release-pr': $.release.createReleasePR
  + $.common.job.withNeeds(buildImageSteps + validationSteps),
```

| | now | gate moved |
| --- | --- | --- |
| check gate | 0:01 → 3:56 | 0:01 → 3:56 *(parallel)* |
| `version` | 3:57 → 4:49 | 0:01 → 0:53 |
| builds | 4:51 → 7:53 | 0:55 → 3:59 |
| `create-release-pr` | 7:55 → 8:47 | 4:01 → 4:53 |

**~8m49s → ~4m53s**, so roughly half the run. What it costs is compute on failing PRs: `version`, `dist` and all five image jobs would run instead of being skipped — about seven extra job-runs per failing PR, three of them on `ubuntu-arm64`. GAR generic would also collect artifacts for commits that failed their checks, which is harmless clutter given nothing consumes them unless the release PR gets created. Needs a call on whether it goes in unconditionally or behind a parameter, because `releasePRWorkflow` is shared and Loki inherits the looser gate on its next re-vendor.

### 2. `GOCACHE` is thrown away every run — 92.5s per driver build

`loki-docker-driver` is the long pole of the build phase at 3m02s, and its `Build and export` step accounts for 1m48s of that:

| stage | time |
| --- | --- |
| `RUN make clean && make ... docker-driver` (`go build`) | **92.5s** |
| buildkit boot | 9.5s |
| pull `golang:1.24` | 9.9s |
| load build context | 3.2s |
| `apk add`, COPYs, export | ~5s |

At heart this isn't a layer-cache problem — it's one small binary compiled against a cold build cache, recompiling the whole vendored dependency tree, in every arch job, on every run. Adding `cache-from`/`cache-to` on its own wouldn't fix it either: `COPY . /src/loki` sits before `RUN make`, so the build layer invalidates on any source change and only the base-image pull and boot (~20s) come back. Recovering the 92.5s means persisting `GOCACHE` — a BuildKit cache mount plus something to carry it across ephemeral runners — or building the binary on the runner with `actions/setup-go` caching and copying it into a minimal image.

Worth flagging that the Dockerfiles here are fixtures. The real ones live in `grafana/loki`, so making Loki's builds faster needs the matching change over there; from this repo we can only speed up this repo's CI.

### 3. `install dependencies` runs seven times in the check gate

Seven separate `install dependencies` steps, at 1m04s, 1m04s, 58s, 28s, 25s, 24s and 24s. They run in parallel so they don't sum on the clock, but `golangciLint`'s own 1m04s is 28% of the 3m55s gate that blocks the entire workflow. Caching it takes roughly a minute off the gate, and since it's this repo's own workflow there's no downstream coordination to organise.

### Why the ordering matters

Once finding 1 is in, the two parallel paths land within three seconds of each other — check at 3:56, builds at 3:59 — so the run is then gated by both at once. That makes findings 2 and 3 complementary rather than alternatives: cutting a minute off only one of them moves the total by about five seconds, because the other path immediately becomes the gate.

## Verified locally

Ran the whole path against a local crane registry before pushing: buildx export → `push-images` load/push/manifest → `docker plugin create` accepted the fake rootfs with the real `config.json` → `docker plugin push` → crane mirror to a second registry. All clean. Filename-to-tag parsing was checked against `push-images`' own regex, and `shellcheck` is clean on all four generated `run` blocks.

## Known trade-offs

An adversarial review flagged two things, both accepted for now on the grounds that this is a measurement exercise:

1. **The artifact contract isn't gated on PRs any more.** The old jobs proved that the tarballs the build jobs actually upload can be downloaded and consumed by `push-images`. The fixtures name their own tarballs, so a rename in `build.libsonnet` without a matching change to the `push-images` filename regex would now sail through CI and only turn up at release time. Worth fixing properly if we adopt this — cheapest option is having each build job assert its own tar name parses, which costs no wall-clock since it happens inside jobs that are already running in parallel.
2. **The fixtures are amd64-only**, while the release path handles three platforms and a real manifest list. Adding arm64 is nearly free for a scratch image (no QEMU needed) if we decide the coverage is worth it.

Also worth noting, pre-existing and unrelated: `RELEASE_LIB_REF` is pinned to `main`, so these jobs test `push-images` from `main` rather than from the PR. Changes to the action itself are only covered by `testPushPackage`'s unit tests.


